### PR TITLE
[ADMINAPI-1009] AdminApi 1.4.0 with Ed-Fi v5.3 errors on GET /v1/claimSets

### DIFF
--- a/Application/EdFi.Ods.AdminApi/EdFi.Ods.AdminApi.csproj
+++ b/Application/EdFi.Ods.AdminApi/EdFi.Ods.AdminApi.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
     <PackageReference Include="NJsonSchema" Version="10.9.0" />
-    <PackageReference Include="Npgsql" Version="8.0.1" />
+    <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="OpenIddict.AspNetCore" Version="4.4.0" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.4.0" />

--- a/Application/EdFi.Ods.AdminApi/Features/RequestLoggingMiddleware.cs
+++ b/Application/EdFi.Ods.AdminApi/Features/RequestLoggingMiddleware.cs
@@ -8,6 +8,7 @@ using EdFi.Ods.AdminApi.Infrastructure.ErrorHandling;
 using FluentValidation;
 using System.Net;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace EdFi.Ods.AdminApi.Features;
 
@@ -84,6 +85,7 @@ public class RequestLoggingMiddleware
                     break;
 
                 default:
+                    response.StatusCode = (int)HttpStatusCode.InternalServerError;
                     logger.LogError(JsonSerializer.Serialize(new { message = "An uncaught error has occurred", error = new { ex.Message, ex.StackTrace }, traceId = context.TraceIdentifier }));
                     await response.WriteAsync(JsonSerializer.Serialize(new { message = "The server encountered an unexpected condition that prevented it from fulfilling the request." }));
                     break;

--- a/Application/EdFi.Ods.AdminApi/Features/RequestLoggingMiddleware.cs
+++ b/Application/EdFi.Ods.AdminApi/Features/RequestLoggingMiddleware.cs
@@ -8,7 +8,6 @@ using EdFi.Ods.AdminApi.Infrastructure.ErrorHandling;
 using FluentValidation;
 using System.Net;
 using System.Text.Json;
-using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace EdFi.Ods.AdminApi.Features;
 

--- a/Application/EdFi.Ods.AdminApi/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.AdminApi/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -187,6 +187,7 @@ public static class WebApplicationBuilderExtensions
 
             var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseNpgsql(securityConnectionString);
+            optionsBuilder.UseLowerCaseNamingConvention();
             var context = new PostgresSecurityContext(optionsBuilder.Options);
 
             webApplicationBuilder.Services.AddScoped<Compatability::EdFi.SecurityCompatiblity53.DataAccess.Contexts.ISecurityContext>(


### PR DESCRIPTION
- Update Npgsql to 8.0.3
- Change status error code to InternalServerError
- Adding UseLowerCaseNamingConvention to securityConnectionString