### PR TITLE
[ADMINAPI-1349] Refactor versioning logic

### DIFF
--- a/.github/workflows/on-merge-or-tag.yml
+++ b/.github/workflows/on-merge-or-tag.yml
@@ -39,12 +39,8 @@ jobs:
       - name: Set Version Numbers
         id: versions
         run: |
-          $apiPrefix = "v"
-
-          # Install the MinVer CLI tool
-          &dotnet tool install --global minver-cli
-
-          "admin-api=$($apiPrefix)$(minver -t $apiPrefix)" >> $env:GITHUB_OUTPUT
+          $apiVersion = & ./eng/get-version.ps1
+          "admin-api=$apiVersion" >> $env:GITHUB_OUTPUT
 
       - name: Create Admin API Pre-Release
         run: |

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -44,10 +44,7 @@ jobs:
         run: |
           $apiPrefix = "v"
 
-          # Install the MinVer CLI tool
-          &dotnet tool install --global minver-cli
-
-          $apiVersion = $(minver -t $apiPrefix)
+          $apiVersion = & ./eng/get-version.ps1
 
           # Full release name
           "admin-api=$apiVersion" >> $env:GITHUB_OUTPUT

--- a/eng/get-version.ps1
+++ b/eng/get-version.ps1
@@ -1,0 +1,30 @@
+$apiPrefix = "v"
+
+# Provisional workaround for branches that do not have the latest tags
+# Check if we have a v2.x tag anywhere in the repo
+$latestV2Tag = git tag -l "v2.*" --sort=-v:refname | Select-Object -First 1
+          
+if ($latestV2Tag)
+{
+  # Parse version
+  $version = $latestV2Tag -replace '^v', ''
+  $parts = $version -split '\.'
+  $major = $parts[0]
+  $minor = $parts[1]
+  $patch = [int]$parts[2] + 1
+            
+  # Count commits since the latest tag
+  $commitCount = git rev-list "$latestV2Tag..HEAD" --count
+            
+  # Format as X.X.X-alpha.Y
+  $apiVersion = "$apiPrefix$major.$minor.$patch-alpha.0.$commitCount"
+}
+else
+{
+  # Install the MinVer CLI tool
+  &dotnet tool install --global minver-cli
+  # Fallback to MinVer
+  $apiVersion = $(minver -t $apiPrefix)
+}          
+
+return $apiVersion


### PR DESCRIPTION
This pull request updates the way version numbers are determined for the Admin API in CI workflows by introducing a new PowerShell script, `eng/get-version.ps1`. This script provides a custom versioning logic that prioritizes the latest `v2.x` git tag and increments it, falling back to MinVer if no such tag exists. The workflows are updated to use this script instead of directly invoking MinVer.

**Versioning logic improvements:**

* Added new script `eng/get-version.ps1` to determine the API version. It checks for the latest `v2.x` tag, increments the patch version, and appends commit count as a pre-release identifier. If no such tag exists, it installs and uses MinVer as a fallback.

**Workflow updates:**

* Updated `.github/workflows/on-merge-or-tag.yml` to use `eng/get-version.ps1` for setting the Admin API version, replacing the previous inline MinVer logic.
* Updated `.github/workflows/on-prerelease.yml` to use `eng/get-version.ps1` for determining the Admin API version, removing direct MinVer usage.