### PR TITLE
[ADMINAPI-1368] feat: Delete DbInstance endpoint

### DIFF
--- a/Application/EdFi.Ods.AdminApi.DBTests/Database/CommandTests/DeleteDbInstanceCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApi.DBTests/Database/CommandTests/DeleteDbInstanceCommandTests.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Linq;
+using EdFi.Ods.AdminApi.Common.Constants;
+using EdFi.Ods.AdminApi.Common.Infrastructure.Models;
+using EdFi.Ods.AdminApi.Infrastructure.Database.Commands;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.AdminApi.DBTests.Database.CommandTests;
+
+[TestFixture]
+public class DeleteDbInstanceCommandTests : AdminApiDbContextTestBase
+{
+    [Test]
+    public void ShouldSetStatusToPendingDelete()
+    {
+        var instance = new DbInstance
+        {
+            Name = "Delete Test Instance",
+            Status = DbInstanceStatus.Pending.ToString(),
+            DatabaseTemplate = "Minimal",
+            LastRefreshed = DateTime.UtcNow
+        };
+        Save(instance);
+
+        Transaction(context =>
+        {
+            var command = new DeleteDbInstanceCommand(context);
+            command.Execute(instance.Id);
+        });
+
+        Transaction(context =>
+        {
+            var updated = context.DbInstances.Single(d => d.Id == instance.Id);
+            updated.Status.ShouldBe(DbInstanceStatus.PendingDelete.ToString());
+        });
+    }
+
+    [Test]
+    public void ShouldUpdateLastModifiedDate()
+    {
+        var before = DateTime.UtcNow;
+        var instance = new DbInstance
+        {
+            Name = "Timestamp Test Instance",
+            Status = DbInstanceStatus.Pending.ToString(),
+            DatabaseTemplate = "Minimal",
+            LastRefreshed = DateTime.UtcNow
+        };
+        Save(instance);
+
+        Transaction(context =>
+        {
+            var command = new DeleteDbInstanceCommand(context);
+            command.Execute(instance.Id);
+        });
+
+        Transaction(context =>
+        {
+            var updated = context.DbInstances.Single(d => d.Id == instance.Id);
+            updated.LastModifiedDate.ShouldNotBeNull();
+            updated.LastModifiedDate!.Value.ShouldBeGreaterThanOrEqualTo(before);
+        });
+    }
+
+    [Test]
+    public void ShouldNotHardDeleteRecord()
+    {
+        var instance = new DbInstance
+        {
+            Name = "No Hard Delete Instance",
+            Status = DbInstanceStatus.Pending.ToString(),
+            DatabaseTemplate = "Minimal",
+            LastRefreshed = DateTime.UtcNow
+        };
+        Save(instance);
+
+        Transaction(context =>
+        {
+            var command = new DeleteDbInstanceCommand(context);
+            command.Execute(instance.Id);
+        });
+
+        Transaction(context =>
+        {
+            var stillExists = context.DbInstances.Any(d => d.Id == instance.Id);
+            stillExists.ShouldBeTrue();
+        });
+    }
+}

--- a/Application/EdFi.Ods.AdminApi.UnitTests/Features/DbInstances/DeleteDbInstanceTests.cs
+++ b/Application/EdFi.Ods.AdminApi.UnitTests/Features/DbInstances/DeleteDbInstanceTests.cs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Threading.Tasks;
+using EdFi.Ods.AdminApi.Common.Constants;
+using EdFi.Ods.AdminApi.Common.Infrastructure.ErrorHandling;
+using EdFi.Ods.AdminApi.Common.Infrastructure.Models;
+using EdFi.Ods.AdminApi.Features.DbInstances;
+using EdFi.Ods.AdminApi.Infrastructure.Database.Commands;
+using EdFi.Ods.AdminApi.Infrastructure.Database.Queries;
+using FakeItEasy;
+using FluentValidation;
+using Microsoft.AspNetCore.Http.HttpResults;
+using NUnit.Framework;
+using Shouldly;
+
+#nullable enable
+
+namespace EdFi.Ods.AdminApi.UnitTests.Features.DbInstances;
+
+[TestFixture]
+public class DeleteDbInstanceTests
+{
+    private IGetDbInstanceByIdQuery _getDbInstanceByIdQuery = null!;
+    private IDeleteDbInstanceCommand _deleteDbInstanceCommand = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _getDbInstanceByIdQuery = A.Fake<IGetDbInstanceByIdQuery>();
+        _deleteDbInstanceCommand = A.Fake<IDeleteDbInstanceCommand>();
+    }
+
+    [Test]
+    public async Task Handle_WhenDbInstanceNotFound_ThrowsNotFoundException()
+    {
+        A.CallTo(() => _getDbInstanceByIdQuery.Execute(99)).Returns(null);
+
+        await Should.ThrowAsync<NotFoundException<int>>(() =>
+            DeleteDbInstance.Handle(_getDbInstanceByIdQuery, _deleteDbInstanceCommand, 99)
+        );
+    }
+
+    [Test]
+    public async Task Handle_WhenStatusIsPending_ThrowsValidationException()
+    {
+        var dbInstance = new DbInstance
+        {
+            Id = 1,
+            Name = "Test",
+            Status = DbInstanceStatus.Pending.ToString(),
+            DatabaseTemplate = "Minimal",
+        };
+        A.CallTo(() => _getDbInstanceByIdQuery.Execute(1)).Returns(dbInstance);
+
+        var ex = await Should.ThrowAsync<ValidationException>(() =>
+            DeleteDbInstance.Handle(_getDbInstanceByIdQuery, _deleteDbInstanceCommand, 1)
+        );
+
+        ex.Errors.ShouldContain(e => e.ErrorMessage.Contains("provisioned"));
+        A.CallTo(() => _deleteDbInstanceCommand.Execute(A<int>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenStatusIsInProgress_ThrowsValidationException()
+    {
+        var dbInstance = new DbInstance
+        {
+            Id = 2,
+            Name = "Test",
+            Status = DbInstanceStatus.InProgress.ToString(),
+            DatabaseTemplate = "Minimal",
+        };
+        A.CallTo(() => _getDbInstanceByIdQuery.Execute(2)).Returns(dbInstance);
+
+        var ex = await Should.ThrowAsync<ValidationException>(
+            () => DeleteDbInstance.Handle(_getDbInstanceByIdQuery, _deleteDbInstanceCommand, 2)
+        );
+
+        ex.Errors.ShouldContain(e => e.ErrorMessage.Contains("provisioned"));
+        A.CallTo(() => _deleteDbInstanceCommand.Execute(A<int>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenStatusIsCompleted_ExecutesCommandAndReturnsNoContent()
+    {
+        var dbInstance = new DbInstance
+        {
+            Id = 3,
+            Name = "Test",
+            Status = DbInstanceStatus.Completed.ToString(),
+            DatabaseTemplate = "Minimal",
+        };
+        A.CallTo(() => _getDbInstanceByIdQuery.Execute(3)).Returns(dbInstance);
+
+        var result = await DeleteDbInstance.Handle(_getDbInstanceByIdQuery, _deleteDbInstanceCommand, 3);
+
+        result.ShouldBeOfType<NoContent>();
+        A.CallTo(() => _deleteDbInstanceCommand.Execute(3)).MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task Handle_WhenStatusIsDeleteFailed_ExecutesCommandAndReturnsNoContent()
+    {
+        var dbInstance = new DbInstance
+        {
+            Id = 4,
+            Name = "Test",
+            Status = DbInstanceStatus.DeleteFailed.ToString(),
+            DatabaseTemplate = "Minimal",
+        };
+        A.CallTo(() => _getDbInstanceByIdQuery.Execute(4)).Returns(dbInstance);
+
+        var result = await DeleteDbInstance.Handle(_getDbInstanceByIdQuery, _deleteDbInstanceCommand, 4);
+
+        result.ShouldBeOfType<NoContent>();
+        A.CallTo(() => _deleteDbInstanceCommand.Execute(4)).MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task Handle_WhenStatusIsPendingDelete_ThrowsValidationException()
+    {
+        var dbInstance = new DbInstance
+        {
+            Id = 5,
+            Name = "Test",
+            Status = DbInstanceStatus.PendingDelete.ToString(),
+            DatabaseTemplate = "Minimal",
+        };
+        A.CallTo(() => _getDbInstanceByIdQuery.Execute(5)).Returns(dbInstance);
+
+        var ex = await Should.ThrowAsync<ValidationException>(() =>
+            DeleteDbInstance.Handle(_getDbInstanceByIdQuery, _deleteDbInstanceCommand, 5)
+        );
+
+        ex.Errors.ShouldContain(e => e.ErrorMessage.Contains("queued for deletion"));
+        A.CallTo(() => _deleteDbInstanceCommand.Execute(A<int>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenStatusIsError_ThrowsValidationException()
+    {
+        var dbInstance = new DbInstance
+        {
+            Id = 6,
+            Name = "Test",
+            Status = DbInstanceStatus.Error.ToString(),
+            DatabaseTemplate = "Minimal",
+        };
+        A.CallTo(() => _getDbInstanceByIdQuery.Execute(6)).Returns(dbInstance);
+
+        var ex = await Should.ThrowAsync<ValidationException>(() =>
+            DeleteDbInstance.Handle(_getDbInstanceByIdQuery, _deleteDbInstanceCommand, 6)
+        );
+
+        ex.Errors.ShouldContain(e => e.ErrorMessage.Contains("error during provisioning"));
+        A.CallTo(() => _deleteDbInstanceCommand.Execute(A<int>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task Handle_WhenStatusIsDeleted_ThrowsNotFoundException()
+    {
+        var dbInstance = new DbInstance
+        {
+            Id = 7,
+            Name = "Test",
+            Status = DbInstanceStatus.Deleted.ToString(),
+            DatabaseTemplate = "Minimal",
+        };
+        A.CallTo(() => _getDbInstanceByIdQuery.Execute(7)).Returns(dbInstance);
+
+        await Should.ThrowAsync<NotFoundException<int>>(() =>
+            DeleteDbInstance.Handle(_getDbInstanceByIdQuery, _deleteDbInstanceCommand, 7)
+        );
+
+        A.CallTo(() => _deleteDbInstanceCommand.Execute(A<int>._)).MustNotHaveHappened();
+    }
+}
+
+#nullable restore

--- a/Application/EdFi.Ods.AdminApi.UnitTests/Infrastructure/Database/Commands/DeleteDbInstanceCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApi.UnitTests/Infrastructure/Database/Commands/DeleteDbInstanceCommandTests.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EdFi.Ods.AdminApi.Common.Constants;
+using EdFi.Ods.AdminApi.Common.Infrastructure.Models;
+using EdFi.Ods.AdminApi.Infrastructure;
+using EdFi.Ods.AdminApi.Infrastructure.Database.Commands;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Shouldly;
+
+#nullable enable
+
+namespace EdFi.Ods.AdminApi.UnitTests.Infrastructure.Database.Commands;
+
+[TestFixture]
+public class DeleteDbInstanceCommandTests
+{
+    private static AdminApiDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AdminApiDbContext>()
+            .UseInMemoryDatabase(databaseName: $"DeleteDbInstanceCommand_{Guid.NewGuid()}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?> { ["AppSettings:DatabaseEngine"] = "SqlServer" }
+            )
+            .Build();
+        return new AdminApiDbContext(options, configuration);
+    }
+
+    [Test]
+    public void Execute_SetsStatusToPendingDelete()
+    {
+        using var context = CreateContext();
+        var instance = new DbInstance
+        {
+            Name = "Test Instance",
+            Status = DbInstanceStatus.Pending.ToString(),
+            DatabaseTemplate = "Minimal",
+            LastRefreshed = DateTime.UtcNow,
+        };
+        context.DbInstances.Add(instance);
+        context.SaveChanges();
+
+        var command = new DeleteDbInstanceCommand(context);
+        command.Execute(instance.Id);
+
+        var updated = context.DbInstances.Single(d => d.Id == instance.Id);
+        updated.Status.ShouldBe(DbInstanceStatus.PendingDelete.ToString());
+    }
+
+    [Test]
+    public void Execute_UpdatesLastModifiedDate()
+    {
+        using var context = CreateContext();
+        var before = DateTime.UtcNow;
+        var instance = new DbInstance
+        {
+            Name = "Test Instance",
+            Status = DbInstanceStatus.Pending.ToString(),
+            DatabaseTemplate = "Minimal",
+            LastRefreshed = DateTime.UtcNow,
+        };
+        context.DbInstances.Add(instance);
+        context.SaveChanges();
+
+        var command = new DeleteDbInstanceCommand(context);
+        command.Execute(instance.Id);
+
+        var updated = context.DbInstances.Single(d => d.Id == instance.Id);
+        updated.LastModifiedDate.ShouldNotBeNull();
+        updated.LastModifiedDate!.Value.ShouldBeGreaterThanOrEqualTo(before);
+    }
+
+    [Test]
+    public void Execute_WithNonExistentId_ThrowsArgumentException()
+    {
+        using var context = CreateContext();
+        var command = new DeleteDbInstanceCommand(context);
+
+        Should.Throw<ArgumentException>(() => command.Execute(9999));
+    }
+}
+
+#nullable restore

--- a/Application/EdFi.Ods.AdminApi.UnitTests/Infrastructure/Database/Commands/DeleteDbInstanceCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApi.UnitTests/Infrastructure/Database/Commands/DeleteDbInstanceCommandTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EdFi.Ods.AdminApi.Common.Constants;
+using EdFi.Ods.AdminApi.Common.Infrastructure.ErrorHandling;
 using EdFi.Ods.AdminApi.Common.Infrastructure.Models;
 using EdFi.Ods.AdminApi.Infrastructure;
 using EdFi.Ods.AdminApi.Infrastructure.Database.Commands;
@@ -80,12 +81,31 @@ public class DeleteDbInstanceCommandTests
     }
 
     [Test]
-    public void Execute_WithNonExistentId_ThrowsArgumentException()
+    public void Execute_WithNonExistentId_ThrowsNotFoundException()
     {
         using var context = CreateContext();
         var command = new DeleteDbInstanceCommand(context);
 
-        Should.Throw<ArgumentException>(() => command.Execute(9999));
+        Should.Throw<NotFoundException<int>>(() => command.Execute(9999));
+    }
+
+    [Test]
+    public void Execute_WhenStatusIsDeleted_ThrowsNotFoundException()
+    {
+        using var context = CreateContext();
+        var instance = new DbInstance
+        {
+            Name = "Test Instance",
+            Status = DbInstanceStatus.Deleted.ToString(),
+            DatabaseTemplate = "Minimal",
+            LastRefreshed = DateTime.UtcNow,
+        };
+        context.DbInstances.Add(instance);
+        context.SaveChanges();
+
+        var command = new DeleteDbInstanceCommand(context);
+
+        Should.Throw<NotFoundException<int>>(() => command.Execute(instance.Id));
     }
 }
 

--- a/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/DbInstances/DELETE - DbInstance - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/DbInstances/DELETE - DbInstance - Not Found.bru
@@ -1,0 +1,31 @@
+meta {
+  name: DbInstances - Delete - Not Found
+  type: http
+  seq: 12
+}
+
+delete {
+  url: {{API_URL}}/v2/dbinstances/0
+  body: none
+  auth: inherit
+}
+
+script:post-response {
+  test("DELETE DbInstance Not Found: Status code is Not Found", function () {
+    expect(res.getStatus()).to.equal(404);
+  });
+
+  const response = res.getBody();
+
+  test("DELETE DbInstance Not Found: Response matches error format", function () {
+    expect(response).to.have.property("title");
+  });
+
+  test("DELETE DbInstance Not Found: Response title is helpful and accurate", function () {
+    expect(response.title.toLowerCase()).to.contain("not found");
+  });
+}
+
+settings {
+  encodeUrl: true
+}

--- a/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/DbInstances/DELETE - DbInstance - Pending Status.bru
+++ b/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/DbInstances/DELETE - DbInstance - Pending Status.bru
@@ -1,0 +1,31 @@
+meta {
+  name: DbInstances - Delete - Pending Status
+  type: http
+  seq: 14
+}
+
+delete {
+  url: {{API_URL}}/v2/dbinstances/{{FreshPendingDbInstanceId}}
+  body: none
+  auth: inherit
+}
+
+script:post-response {
+  test("DELETE DbInstance Pending: Status code is Bad Request", function () {
+    expect(res.getStatus()).to.equal(400);
+  });
+
+  const response = res.getBody();
+
+  test("DELETE DbInstance Pending: Response matches error format", function () {
+    expect(response).to.have.property("title");
+  });
+
+  test("DELETE DbInstance Pending: Response contains blocking message", function () {
+    expect(JSON.stringify(response).toLowerCase()).to.contain("provisioned");
+  });
+}
+
+settings {
+  encodeUrl: true
+}

--- a/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/DbInstances/POST - DbInstance - For Delete Test.bru
+++ b/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/DbInstances/POST - DbInstance - For Delete Test.bru
@@ -1,0 +1,38 @@
+meta {
+  name: DbInstances - Post - For Delete Test
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{API_URL}}/v2/dbinstances
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "Delete Test DB Instance",
+    "databaseTemplate": "Minimal"
+  }
+}
+
+script:post-response {
+  test("POST DbInstances For Delete Test: Status code is Accepted", function () {
+    expect(res.getStatus()).to.equal(202);
+  });
+
+  test("POST DbInstances For Delete Test: Response includes location in header", function () {
+    expect(res.getHeaders()).to.have.property("location");
+    const location = res.getHeader("location");
+    const parts = location.split("/");
+    const id = parts[parts.length - 1];
+    if (id) {
+      bru.setVar("FreshPendingDbInstanceId", id);
+    }
+  });
+}
+
+settings {
+  encodeUrl: true
+}

--- a/Application/EdFi.Ods.AdminApi/Features/DbInstances/AddDbInstance.cs
+++ b/Application/EdFi.Ods.AdminApi/Features/DbInstances/AddDbInstance.cs
@@ -17,7 +17,7 @@ public class AddDbInstance : IFeature
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         AdminApiEndpointBuilder
-            .MapPost(endpoints, "/dbinstances", Handle)
+            .MapPost(endpoints, "/dbInstances", Handle)
             .WithDefaultSummaryAndDescription()
             .WithRouteOptions(b => b.WithResponseCode(202))
             .BuildForVersions(AdminApiVersions.V2);

--- a/Application/EdFi.Ods.AdminApi/Features/DbInstances/DeleteDbInstance.cs
+++ b/Application/EdFi.Ods.AdminApi/Features/DbInstances/DeleteDbInstance.cs
@@ -19,7 +19,7 @@ public class DeleteDbInstance : IFeature
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         AdminApiEndpointBuilder
-            .MapDelete(endpoints, "/dbinstances/{id}", Handle)
+            .MapDelete(endpoints, "/dbInstances/{id}", Handle)
             .WithDefaultSummaryAndDescription()
             .WithRouteOptions(b => b.WithResponseCode(204))
             .BuildForVersions(AdminApiVersions.V2);

--- a/Application/EdFi.Ods.AdminApi/Features/DbInstances/DeleteDbInstance.cs
+++ b/Application/EdFi.Ods.AdminApi/Features/DbInstances/DeleteDbInstance.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Ods.AdminApi.Common.Constants;
+using EdFi.Ods.AdminApi.Common.Features;
+using EdFi.Ods.AdminApi.Common.Infrastructure;
+using EdFi.Ods.AdminApi.Common.Infrastructure.ErrorHandling;
+using EdFi.Ods.AdminApi.Infrastructure.Database.Commands;
+using EdFi.Ods.AdminApi.Infrastructure.Database.Queries;
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace EdFi.Ods.AdminApi.Features.DbInstances;
+
+public class DeleteDbInstance : IFeature
+{
+    public void MapEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        AdminApiEndpointBuilder
+            .MapDelete(endpoints, "/dbinstances/{id}", Handle)
+            .WithDefaultSummaryAndDescription()
+            .WithRouteOptions(b => b.WithResponseCode(204))
+            .BuildForVersions(AdminApiVersions.V2);
+    }
+
+    public static Task<IResult> Handle(
+        IGetDbInstanceByIdQuery getDbInstanceByIdQuery,
+        IDeleteDbInstanceCommand deleteDbInstanceCommand,
+        int id
+    )
+    {
+        var dbInstance = getDbInstanceByIdQuery.Execute(id);
+        if (dbInstance is null)
+            throw new NotFoundException<int>("dbInstance", id);
+
+        if (dbInstance.Status == DbInstanceStatus.Deleted.ToString())
+            throw new NotFoundException<int>("dbInstance", id);
+
+        var blockingMessage = GetBlockingStatusMessage(dbInstance.Status);
+        if (blockingMessage is not null)
+            throw new ValidationException([new ValidationFailure(nameof(id), blockingMessage)]);
+
+        deleteDbInstanceCommand.Execute(id);
+        return Task.FromResult(Results.NoContent());
+    }
+
+    private static string? GetBlockingStatusMessage(string status)
+    {
+        if (Enum.TryParse<DbInstanceStatus>(status, out var parsed))
+        {
+            return parsed switch
+            {
+                DbInstanceStatus.Pending => "DbInstance is being provisioned. Wait for the creation job to complete before deleting.",
+                DbInstanceStatus.InProgress => "DbInstance is currently being provisioned. Wait for the creation job to complete before deleting.",
+                DbInstanceStatus.PendingDelete => "DbInstance is already queued for deletion.",
+                DbInstanceStatus.Error => "DbInstance encountered an error during provisioning. Check job status before retrying.",
+                _ => null,
+            };
+        }
+
+        return null;
+    }
+}

--- a/Application/EdFi.Ods.AdminApi/Features/DbInstances/ReadDbInstance.cs
+++ b/Application/EdFi.Ods.AdminApi/Features/DbInstances/ReadDbInstance.cs
@@ -14,12 +14,12 @@ public class ReadDbInstance : IFeature
 {
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
-        AdminApiEndpointBuilder.MapGet(endpoints, "/dbinstances", GetDbInstances)
+        AdminApiEndpointBuilder.MapGet(endpoints, "/dbInstances", GetDbInstances)
             .WithDefaultSummaryAndDescription()
             .WithRouteOptions(b => b.WithResponse<DbInstanceModel[]>(200))
             .BuildForVersions(AdminApiVersions.V2);
 
-        AdminApiEndpointBuilder.MapGet(endpoints, "/dbinstances/{id}", GetDbInstance)
+        AdminApiEndpointBuilder.MapGet(endpoints, "/dbInstances/{id}", GetDbInstance)
             .WithDefaultSummaryAndDescription()
             .WithRouteOptions(b => b.WithResponse<DbInstanceModel>(200))
             .BuildForVersions(AdminApiVersions.V2);

--- a/Application/EdFi.Ods.AdminApi/Infrastructure/Database/Commands/DeleteDbInstanceCommand.cs
+++ b/Application/EdFi.Ods.AdminApi/Infrastructure/Database/Commands/DeleteDbInstanceCommand.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.Ods.AdminApi.Common.Constants;
+using EdFi.Ods.AdminApi.Common.Infrastructure.ErrorHandling;
 
 namespace EdFi.Ods.AdminApi.Infrastructure.Database.Commands;
 
@@ -25,7 +26,10 @@ public class DeleteDbInstanceCommand : IDeleteDbInstanceCommand
     {
         var dbInstance =
             _context.DbInstances.Find(id)
-            ?? throw new ArgumentException($"DbInstance with ID {id} was not found.", nameof(id));
+            ?? throw new NotFoundException<int>("dbInstance", id);
+
+        if (dbInstance.Status == DbInstanceStatus.Deleted.ToString())
+            throw new NotFoundException<int>("dbInstance", id);
 
         dbInstance.Status = DbInstanceStatus.PendingDelete.ToString();
         dbInstance.LastModifiedDate = DateTime.UtcNow;

--- a/Application/EdFi.Ods.AdminApi/Infrastructure/Database/Commands/DeleteDbInstanceCommand.cs
+++ b/Application/EdFi.Ods.AdminApi/Infrastructure/Database/Commands/DeleteDbInstanceCommand.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Ods.AdminApi.Common.Constants;
+
+namespace EdFi.Ods.AdminApi.Infrastructure.Database.Commands;
+
+public interface IDeleteDbInstanceCommand
+{
+    void Execute(int id);
+}
+
+public class DeleteDbInstanceCommand : IDeleteDbInstanceCommand
+{
+    private readonly AdminApiDbContext _context;
+
+    public DeleteDbInstanceCommand(AdminApiDbContext context)
+    {
+        _context = context;
+    }
+
+    public void Execute(int id)
+    {
+        var dbInstance =
+            _context.DbInstances.Find(id)
+            ?? throw new ArgumentException($"DbInstance with ID {id} was not found.", nameof(id));
+
+        dbInstance.Status = DbInstanceStatus.PendingDelete.ToString();
+        dbInstance.LastModifiedDate = DateTime.UtcNow;
+
+        _context.SaveChanges();
+    }
+}


### PR DESCRIPTION
This pull request introduces the implementation of the "Delete DbInstance" feature for the Admin API, including endpoint logic, command handling, and comprehensive automated tests. The changes ensure that deletion requests are validated based on the current status of the database instance, prevent hard deletes, and provide appropriate error responses for invalid operations.

The most important changes are:

**Feature Implementation:**

* Added the `DeleteDbInstance` endpoint in `DeleteDbInstance.cs`, which validates the instance's status before allowing deletion, and returns meaningful error messages for blocked or invalid operations. The endpoint only allows deletion when the instance is in a valid state and sets the status to `PendingDelete` instead of removing the record.
* Created the `DeleteDbInstanceCommand` in `DeleteDbInstanceCommand.cs`, which updates the status of the `DbInstance` to `PendingDelete` and updates the `LastModifiedDate`, rather than performing a hard delete.

**Automated Testing:**

* Added unit tests for the endpoint logic in `DeleteDbInstanceTests.cs`, covering all relevant status scenarios (e.g., not found, pending, in progress, completed, error, already deleted, etc.) to verify correct validation and command execution.
* Added command-level unit tests in `DeleteDbInstanceCommandTests.cs` to ensure the command sets the correct status, updates the timestamp, and throws exceptions for non-existent IDs.
* Added integration-style tests for database behavior in `DeleteDbInstanceCommandTests.cs` under the DBTests project, confirming no hard deletes occur and status/timestamp updates are correct.

**End-to-End (E2E) Testing:**

* Added Bruno E2E test scripts for:
  - Deleting a non-existent instance and verifying a 404 Not Found response.
  - Creating a fresh pending instance for delete tests.
  - Attempting to delete a pending instance and verifying a 400 Bad Request with a helpful error message.