### PR TITLE
[ADMINAPI-1378] - Review and update ClaimSet export format in Admin API v3

### DIFF
--- a/docs/design/claimset-export/README.md
+++ b/docs/design/claimset-export/README.md
@@ -1,0 +1,87 @@
+# Summary
+
+Conduct a spike to evaluate the feasibility and impact of updating the claim set export endpoint in Admin API v3. The goal is to align it with the descriptor-only format used by CMS and provide recommendations or implementation as needed.
+
+## Context
+
+The current claim set export endpoint in Admin API v3 returns the full claim tree, while CMS only returns a descriptor. This discrepancy needs to be addressed.
+
+## Acceptance criteria
+
+- Determine the feasibility of updating the claim set export format.
+- Assess the impact of the proposed changes.
+- Provide recommendations or implementation steps based on the findings.
+- Reference migration utility as needed.
+- Assess the impact of any change on Admin App.
+- Assess the impact of  Name field - should not accept blank character. 
+
+## Other information
+
+- Gap Analysis row reference:
+    - Row 11 – “Claim set export”
+        - GAP: CMS returns only a descriptor; Admin API returns the full claim tree.
+        - Decision: Admin API /v3 – Spike to determine feasibility of new export format (VM to provide reference to migration utility)
+
+- Claim set export
+
+    Admin API emits the full resource-claim tree (actions, default strategies, overrides). CMS returns only a high-level claim set descriptor.
+
+    Action: `GET /v2/claimSets/{{id}}/export`
+
+    Response Payload (CMS)
+    ```
+    {
+    "id": 5,
+    "name": "EdFiSandbox",
+    "_isSystemReserved": true,
+    "_applications": {}
+    }
+    ```
+
+    Response Payload (Admin API)
+    ```
+    {
+    "resourceClaims": [
+        {
+        "id": 1,
+        "name": "types",
+        "actions": [
+            {
+            "name": "Read",
+            "enabled": true
+            }
+        ],
+        "_defaultAuthorizationStrategiesForCRUD": [
+            {
+            "actionId": 2,
+            "actionName": "Read",
+            "authorizationStrategies": [
+                {
+                "authStrategyId": 1,
+                "authStrategyName": "NoFurtherAuthorizationRequired",
+                "isInheritedFromParent": false
+                }
+            ]
+            }
+        ],
+        "authorizationStrategyOverridesForCRUD": [],
+        "children": []
+        }
+    ]
+    }
+    ```
+
+---
+
+# Developer findings
+
+- One of the reason the endpoint is done like that is the ability to import the claimset into adminapi, setting different values in the claimset properties giving the user the right template to import it again with different characteristcs.
+- This also applies in Admin App where user export the claimset, the user edits it manually and then imports it again. This process is doing by using the Admin API endpoints.
+- If we are going to only export the descriptor, it means the user needs to understand the how to override the crud operations or other property structure, probably a good documentation might help with this.
+- The impact in Admin App depends on Admin API changes, since the content is exported as txt file with the JSON payload from Admin API. The import uses the file content to parse it into a JSON payload that will be used in the Admin API import endpoint.
+
+# Plan (Using Superpowers)
+
+- [Spike Design](claimset-export-spike-design.md)
+- [Option (A) Design](claimset-export-spike-design.md)
+

--- a/docs/design/claimset-export/claimset-export-option-a-design.md
+++ b/docs/design/claimset-export/claimset-export-option-a-design.md
@@ -1,0 +1,240 @@
+# Design: Claim Set Export — Option A (CMS Descriptor-Only, Breaking Change)
+
+**Date:** 2026-05-11  
+**Scope:** Admin API v3 only  
+**Related spike:** `docs/superpowers/specs/2026-05-08-claimset-export-spike-design.md`  
+**Type:** Implementation design — concrete notes for each sub-option
+
+---
+
+## Summary
+
+This document expands on **Option A** from the original spike: replacing the current full resource-claim tree export with a CMS-compatible descriptor. The export endpoint would return only `{ id, name, _isSystemReserved, _applications }`, aligning Admin API v3 with CMS.
+
+The core Admin API change is straightforward. The primary complexity lies in deciding how to handle the **export→import round-trip**, which the current system relies on. Three sub-options are documented below.
+
+---
+
+## Core Change — Export Endpoint (All Sub-Options)
+
+**Endpoint:** `GET /v3/claimSets/{id}/export`  
+**Current response:** `ClaimSetDetailsModel` (full resource-claim tree)  
+**New response:** `ClaimSetModel` (CMS-compatible descriptor)
+
+### New Response Contract
+
+```json
+{
+  "id": 5,
+  "name": "EdFiSandbox",
+  "_isSystemReserved": true,
+  "_applications": []
+}
+```
+
+### Implementation — `ExportClaimSet.cs`
+
+**File:** `Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ExportClaimSet.cs`
+
+```csharp
+// Before:
+internal static Task<IResult> GetClaimSet(
+    IGetClaimSetByIdQuery getClaimSetByIdQuery,
+    IGetResourcesByClaimSetIdQuery getResourcesByClaimSetIdQuery,
+    IGetApplicationsByClaimSetIdQuery getApplications, int id)
+{
+    var claimSet = getClaimSetByIdQuery.Execute(id);
+    var allResources = getResourcesByClaimSetIdQuery.AllResources(id);
+    var applications = getApplications.Execute(id);
+    var claimSetData = ClaimSetMapper.ToDetailsModel(claimSet);
+    if (applications != null)
+        claimSetData.Applications = ClaimSetMapper.ToSimpleApplicationModelList(applications);
+    if (allResources != null)
+        claimSetData.ResourceClaims = ClaimSetMapper.ToClaimSetResourceClaimModelList(allResources.ToList());
+    return Task.FromResult(Results.Ok(claimSetData));
+}
+
+// After:
+internal static Task<IResult> GetClaimSet(
+    IGetClaimSetByIdQuery getClaimSetByIdQuery,
+    IGetApplicationsByClaimSetIdQuery getApplications, int id)
+{
+    var claimSet = getClaimSetByIdQuery.Execute(id);
+    var applications = getApplications.Execute(id);
+    var claimSetData = ClaimSetMapper.ToModel(claimSet);
+    if (applications != null)
+        claimSetData.Applications = ClaimSetMapper.ToSimpleApplicationModelList(applications);
+    return Task.FromResult(Results.Ok(claimSetData));
+}
+```
+
+**Notes:**
+- `IGetResourcesByClaimSetIdQuery` is no longer injected into this handler — remove the dependency.
+- `ClaimSetMapper.ToModel()` already exists and returns `ClaimSetModel`. No new model or mapper is needed.
+- The Swagger `WithResponse<ClaimSetDetailsModel>(200)` annotation must be updated to `WithResponse<ClaimSetModel>(200)`.
+- This is a **breaking change** on the `/v3/claimSets/{id}/export` response shape.
+
+---
+
+## The Round-Trip Problem
+
+The original export→import workflow is:
+1. `GET /v3/claimSets/{id}/export` → full-tree JSON saved as `.json` file.
+2. User edits file (changes name, resource claims, strategies).
+3. `POST /v3/claimSets/import` → parses JSON, creates a new claim set with full configuration.
+
+Under Option A, the export no longer contains `resourceClaims`. The import endpoint (`ImportClaimSet.cs`) currently expects a `resourceClaims` array to configure the new claim set. Three sub-options address this.
+
+---
+
+## Sub-Option A1 — Accept the Breakage; Users Build Resource Claims via API
+
+The export round-trip is removed. The import endpoint is unchanged (it still accepts a full `resourceClaims` payload for programmatic use). Users who need to replicate a claim set's resource configuration must do so manually through the resource claim management endpoints.
+
+### Available Resource Claim Endpoints (Admin API v3)
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /v3/claimSets/{claimSetId}/resourceClaimActions` | Adds a resource claim with actions to the claim set |
+| `PUT /v3/claimSets/{claimSetId}/resourceClaimActions/{resourceClaimId}` | Updates resource claim actions |
+| `DELETE /v3/claimSets/{claimSetId}/resourceClaimActions/{resourceClaimId}` | Removes a resource claim from the claim set |
+| `POST /v3/claimSets/{claimSetId}/resourceClaimActions/{resourceClaimId}/overrideAuthorizationStrategy` | Overrides default authorization strategies for a specific action |
+| `POST /v3/claimSets/{claimSetId}/resourceClaimActions/{resourceClaimId}/resetAuthorizationStrategies` | Resets authorization strategy overrides to defaults |
+
+### Admin API Changes
+
+No changes beyond the core export endpoint change. The import endpoint remains as-is.
+
+### Admin App Impact
+
+**Significant.** Admin App currently has no UI for the resource claim management endpoints listed above. Users would have no way to configure resource claims on a claim set through Admin App after importing a descriptor. To make A1 viable in Admin App, the following **new pages/flows** would be required:
+
+| Admin App Feature Needed | Supporting Endpoint |
+|--------------------------|---------------------|
+| Add resource claim to claimset page/form | `POST /v3/claimSets/{id}/resourceClaimActions` |
+| Edit resource claim actions form | `PUT /v3/claimSets/{id}/resourceClaimActions/{resourceClaimId}` |
+| Remove resource claim action | `DELETE /v3/claimSets/{id}/resourceClaimActions/{resourceClaimId}` |
+| Override authorization strategy form | `POST /v3/claimSets/{id}/resourceClaimActions/{resourceClaimId}/overrideAuthorizationStrategy` |
+| Reset authorization strategies | `POST /v3/claimSets/{id}/resourceClaimActions/{resourceClaimId}/resetAuthorizationStrategies` |
+
+**Assessment:** A1 is not low-effort. It shifts complexity from the export format to the Admin App UI, requiring substantial frontend work to cover all resource claim editing scenarios. It is only viable if new Admin App pages are built as part of the same effort.
+
+---
+
+## Sub-Option A2 — Add `GET /v3/claimSets/{id}/export?format=full` for Round-Trip Use
+
+The default `/export` endpoint returns the CMS descriptor. A new, explicitly-named endpoint `/export/full` returns the full resource-claim tree. Admin App (when migrating to v3) uses `/export/full` for its export-as-file flow.
+
+### New Endpoint Contract
+
+```
+GET /v3/claimSets/{id}/export?format=full
+```
+
+**Response:** Same as the current `/export` response (`ClaimSetDetailsModel`).
+
+### Admin API Changes
+
+Add a second route in `ExportClaimSet.cs`:
+
+```csharp
+public void MapEndpoints(IEndpointRouteBuilder endpoints)
+{
+    // CMS-compatible descriptor (new default)
+    AdminApiEndpointBuilder.MapGet(endpoints, "/claimSets/{id}/export", GetClaimSetDescriptor)
+        .WithSummary("Exports a specific claimset descriptor by id (CMS-compatible)")
+        .WithRouteOptions(b => b.WithResponse<ClaimSetModel>(200))
+        .BuildForVersions(AdminApiVersions.V3);
+
+    // Full resource-claim tree (for import round-trip)
+    AdminApiEndpointBuilder.MapGet(endpoints, "/claimSets/{id}/export/full", GetClaimSetFull)
+        .WithSummary("Exports a specific claimset with full resource claim tree by id")
+        .WithRouteOptions(b => b.WithResponse<ClaimSetDetailsModel>(200))
+        .BuildForVersions(AdminApiVersions.V3);
+}
+```
+
+`GetClaimSetDescriptor` uses the simplified handler from the core change above.  
+`GetClaimSetFull` retains the current handler logic (injecting `IGetResourcesByClaimSetIdQuery`).
+
+### Admin App Impact (when migrating to v3)
+
+Minimal. One service call update in the v3 equivalent of `admin-api.v2.service.ts`:
+
+```typescript
+// exportClaimset method: update URL
+.get(`claimSets/${claimSetId}/export?format=full`)
+```
+
+No model changes, no UI changes, no import flow changes.
+
+**Assessment:** Clean separation of concerns. CMS gets its descriptor on the default URL; the full-tree path is explicit and self-documenting. This is the recommended sub-option if Option A is chosen.
+
+---
+
+## Sub-Option A3 — Update Import to Accept Descriptor-Only Payload
+
+Make `resourceClaims` optional in `ImportClaimSetRequest`. If omitted or empty, the claimset is created with no resource claims. The export file (descriptor only) can be re-imported to create a copy of the claim set shell (name only).
+
+### Admin API Changes — `ImportClaimSet.cs`
+
+The `resourceClaims` field is already nullable (`List<ClaimSetResourceClaimModel>?`). The handler already guards with `if (claimSet.ResourceClaims != null && claimSet.ResourceClaims.Any())` in the validator. The main change is:
+
+1. **Remove the validation error** that requires `resourceClaims` to be non-empty (currently implicit in `ResourceClaimValidator`).
+2. **Guard the `addOrEditResourcesOnClaimSetCommand.Execute()` call** to skip it when `resourceClaims` is null or empty:
+
+```csharp
+// In Handle():
+if (request.ResourceClaims != null && request.ResourceClaims.Any())
+{
+    var resourceClaims = ClaimSetMapper.ToResourceClaimList(request.ResourceClaims);
+    var resolvedResourceClaims = strategyResolver.ResolveAuthStrategies(resourceClaims).ToList();
+    addOrEditResourcesOnClaimSetCommand.Execute(addedClaimSetId, resolvedResourceClaims);
+}
+```
+
+3. **Update the Swagger description** to clarify that `resourceClaims` is optional and that omitting it creates a claim set with no resource claims.
+
+### Behavior
+
+| Import payload | Result |
+|----------------|--------|
+| `{ name, resourceClaims: [...] }` | Creates claim set with full resource configuration |
+| `{ name }` or `{ name, resourceClaims: [] }` | Creates an empty claim set shell (no resource claims) |
+
+### Admin App Impact
+
+Admin App's current import flow parses the exported `.json` file and POSTs its content to the import endpoint. If export only returns the descriptor, the imported claimset will be created with no resource claims. Users would then need to add resource claims manually (same Admin App gap as A1).
+
+**Assessment:** A3 reduces the import endpoint friction but does not resolve the Admin App gap — users still have no UI to add resource claims post-import. It is most useful in API-only or scripting scenarios where consumers want to create a named claimset shell and populate it programmatically.
+
+---
+
+## Comparison Summary
+
+| | A1 | A2 | A3 |
+|---|---|---|---|
+| `/export` returns descriptor | ✅ | ✅ | ✅ |
+| Full tree still accessible | ❌ (API only via CRUD) | ✅ (`/export/full`) | ❌ |
+| Import round-trip preserved | ❌ | ✅ (via `/export/full`) | Partial (shell only) |
+| Admin App new pages needed | ✅ (significant) | ❌ | ✅ (same as A1) |
+| Admin API changes | Small | Small + new route | Small + import relaxation |
+| Breaking change | Yes | Yes (default `/export`) | Yes (default `/export`) |
+
+---
+
+## Out of Scope
+
+- Changes to Admin API v1 or v2.
+- Name field whitespace validation (tracked separately in the original spike).
+- Admin App new resource claim management pages (flagged as a dependency of A1/A3 but not designed here).
+- E2E test updates (follow implementation).
+
+---
+
+## Next Steps
+
+1. Decide which sub-option to adopt (A1, A2, or A3).
+2. If A1 or A3: scope the Admin App resource claim management pages as a prerequisite or parallel ticket.
+3. If A2: create implementation tickets for Admin API v3 (`ExportClaimSet.cs` dual-route change) and Admin App service update (change `claimSets/${claimSetId}/export` → `claimSets/${claimSetId}/export/full`).
+4. Update E2E Bruno collections for the new/changed export endpoint(s).

--- a/docs/design/claimset-export/claimset-export-spike-design.md
+++ b/docs/design/claimset-export/claimset-export-spike-design.md
@@ -1,0 +1,221 @@
+# Spike Design: Claim Set Export Format — Admin API v3
+
+**Date:** 2026-05-08  
+**Scope:** Admin API v3 only  
+**Type:** Spike — findings and recommendation (no code changes)
+
+---
+
+## Problem Statement
+
+Admin API v3 `GET /v3/claimSets/{id}/export` returns the full resource-claim tree (actions, default authorization strategies, overrides, children). CMS returns only a lightweight descriptor (`id`, `name`, `_isSystemReserved`, `_applications`). This gap was identified in the Gap Analysis (Row 11 — "Claim set export").
+
+Additionally, the `Name` field on claim set create/import/edit endpoints accepts strings composed entirely of blank characters (spaces, tabs), which can produce unusable claim set names.
+
+---
+
+## Context
+
+### Current Export Behavior (Admin API v3)
+
+**Endpoint:** `GET /v3/claimSets/{id}/export`  
+**Returns:** `ClaimSetDetailsModel` — a full resource-claim tree
+
+```json
+{
+  "id": 1,
+  "name": "EdFiSandbox",
+  "_isSystemReserved": true,
+  "_applications": [],
+  "resourceClaims": [
+    {
+      "id": 1,
+      "name": "types",
+      "actions": [{ "name": "Read", "enabled": true }],
+      "_defaultAuthorizationStrategiesForCRUD": [...],
+      "authorizationStrategyOverridesForCRUD": [],
+      "children": []
+    }
+  ]
+}
+```
+
+### CMS Export Behavior
+
+```json
+{
+  "id": 5,
+  "name": "EdFiSandbox",
+  "_isSystemReserved": true,
+  "_applications": {}
+}
+```
+
+### Export→Import Round-Trip (Critical Dependency)
+
+The existing export endpoint serves a critical workflow:
+1. User exports a claim set → receives the full-tree JSON as a `.json` file (in Admin App).
+2. User edits the file manually (changing name, resource claims, strategies, etc.).
+3. User imports the file → Admin API's `POST /v3/claimSets/import` parses the JSON and creates a new claim set with the full resource configuration.
+
+The import endpoint (`ImportClaimSet.cs`) requires the `resourceClaims` array with full CRUD action and authorization strategy data. Removing this from the export output breaks the round-trip.
+
+---
+
+## Approaches Evaluated
+
+### Option A — Replace full-tree with CMS descriptor (breaking change)
+
+`GET /v3/claimSets/{id}/export` returns only the CMS-compatible descriptor.
+
+**Pros:**
+- Full parity with CMS default export.
+- Simpler response shape.
+
+**Cons:**
+- **Breaks the export→import round-trip.** The import endpoint still needs resource claims; the exported file can no longer be used as an import payload without manual reconstruction.
+- Admin App's export-as-file feature becomes non-functional for re-import use cases.
+- Users must understand the full resource-claim structure to use the import endpoint — documentation alone is a poor substitute.
+
+**Assessment:** Not recommended. The workflow breakage outweighs the benefit of CMS parity.
+
+---
+
+### Option B — CMS descriptor by default; full tree via `?format=full`
+
+- `GET /v3/claimSets/{id}/export` → returns CMS-compatible descriptor (new default behavior).
+- `GET /v3/claimSets/{id}/export?format=full` → returns the existing full resource-claim tree.
+
+**Pros:**
+- Default aligns with CMS — resolves the Gap Analysis finding.
+- Full tree remains available; the export→import round-trip is preserved.
+- Clean, versioned API design. The query parameter is a standard pattern for format negotiation.
+
+**Cons:**
+- **Forward-looking breaking change for Admin App:** Admin App currently uses the v2 Admin API endpoints (`admin-api.v2.service.ts`). Once Admin App migrates to v3, it will call `/export` without a query param and will receive the descriptor by default rather than the full tree. Admin App would need to append `?format=full` to preserve its export→import workflow. This change is minimal and well-contained (one service call).
+- Slight increase in API surface (one query parameter).
+
+**Admin App impact (when migrating to v3):**
+In `packages/api/src/teams/edfi-tenants/starting-blocks/v2/admin-api.v2.service.ts` (or equivalent v3 service):
+```typescript
+// Current (pointing at v2 Admin API):
+.get(`claimSets/${claimSetId}/export`)
+
+// Required when switching to v3:
+.get(`claimSets/${claimSetId}/export?format=full`)
+```
+
+---
+
+### Option C — Keep full-tree as-is; document the gap with migration utility reference
+
+No endpoint change. Document the CMS gap and reference the migration utility for interoperability.
+
+**Pros:**
+- Zero breaking changes.
+- Zero implementation risk.
+
+**Cons:**
+- The CMS gap persists. The Gap Analysis finding remains unresolved.
+- Interoperability between CMS and Admin API exports is left to documentation and tooling.
+
+**Assessment:** Acceptable as a fallback, but fails to close the documented gap.
+
+---
+
+## Recommendation
+
+**Adopt Option B.**
+
+The default export response should align with CMS (descriptor-only), with the full resource-claim tree accessible via `?format=full`. This resolves the Gap Analysis finding, preserves the export→import round-trip, and results in a minimal, well-scoped change to Admin App.
+
+### Proposed Response Contracts
+
+**Default (`GET /v3/claimSets/{id}/export`):**
+```json
+{
+  "id": 5,
+  "name": "EdFiSandbox",
+  "_isSystemReserved": true,
+  "_applications": []
+}
+```
+
+**Full format (`GET /v3/claimSets/{id}/export?format=full`):**
+```json
+{
+  "id": 5,
+  "name": "EdFiSandbox",
+  "_isSystemReserved": true,
+  "_applications": [],
+  "resourceClaims": [...]
+}
+```
+
+### Admin API v3 Implementation Notes
+
+- In `ExportClaimSet.cs` (`EdFi.Ods.AdminApi.V3`): add an optional `format` query parameter (e.g., `string? format = null`).
+- If `format == "full"`, return `ClaimSetDetailsModel` (existing behavior).
+- Otherwise, return `ClaimSetModel` (descriptor only — already exists as the base class).
+- The existing `ClaimSetModel` already maps to the descriptor shape; no new model is needed.
+
+### Admin App Impact Summary
+
+> **Note:** Admin App currently uses Admin API v2 endpoints. The impact below is forward-looking — it applies when Admin App migrates to Admin API v3.
+
+| File | Change Required |
+|------|----------------|
+| `packages/api/.../starting-blocks/v2/admin-api.v2.service.ts` (or v3 equivalent) | Update `exportClaimset` to call `claimSets/{id}/export?format=full` |
+| `packages/fe/.../useClaimsetActions.tsx` | No change needed (calls service method, not endpoint directly) |
+| `packages/models/src/dtos/edfi-admin-api.v2.dto.ts` | Verify DTO still maps correctly to full-tree response (likely no change) |
+
+---
+
+## Finding 2 — Name Field Blank Character Validation
+
+### Problem
+
+The `Name` field on the following endpoints accepts strings composed entirely of blank characters (spaces, tabs):
+- `POST /v3/claimSets` (`AddClaimSet.cs`)
+- `POST /v3/claimSets/import` (`ImportClaimSet.cs`)
+- `PUT /v3/claimSets/{id}` (`EditClaimSet.cs`)
+
+FluentValidation's `NotEmpty()` treats `"   "` (spaces only) as a valid non-empty string. A claim set with a blank name creates an unusable record.
+
+### Current Validators (example from `AddClaimSet.cs`)
+
+```csharp
+RuleFor(m => m.Name).NotEmpty()
+    .Must(BeAUniqueName)
+    .WithMessage(FeatureConstants.ClaimSetAlreadyExistsMessage);
+```
+
+`NotEmpty()` rejects `null` and `""` but passes `"   "`.
+
+### Recommendation
+
+Add a `Must(name => name != null && name.Trim().Length > 0)` rule (or use `.NotEmpty().NotWhitespace()` if using FluentValidation 11+) to all three validators. Return a clear validation message such as `"Name must not consist of blank characters only."`.
+
+This is a low-risk, surgical validation fix that should be implemented alongside or independently of the export format change.
+
+---
+
+## Migration Utility Reference
+
+The Gap Analysis references a migration utility (VM to provide). Once the reference is available, it should be linked here as the recommended tool for migrating CMS-format exports into Admin API-compatible import payloads.
+
+---
+
+## Out of Scope
+
+- Changes to Admin API v1 or v2.
+- Changes to the import endpoint response or request body shape.
+- Updating E2E tests or Bruno collections (these follow implementation).
+
+---
+
+## Next Steps
+
+1. Stakeholder review of this spike document.
+2. Create a separate ticket for the Name field whitespace validation fix across all three endpoints.
+3. Obtain and link the migration utility reference from VM.


### PR DESCRIPTION
This pull request introduces a comprehensive design spike and implementation plan for updating the claim set export endpoint in Admin API v3 to better align with the CMS descriptor-only format. The work includes a summary of findings, a detailed comparison of export format options, and concrete design notes for each approach, with particular attention to the impact on the Admin App and the critical export→import round-trip workflow. Additionally, it documents a recommendation and plan for stricter validation of the claim set Name field.

**Key changes and findings:**

### Claim Set Export Endpoint Redesign

- **Proposal to align Admin API v3 export with CMS:** The default `GET /v3/claimSets/{id}/export` endpoint should return only a lightweight descriptor (id, name, _isSystemReserved, _applications), matching CMS output, rather than the full resource-claim tree. [[1]](diffhunk://#diff-df457c08ca3eedb4d285373d0d174e5f248cb8bc350c9c085af983ce2fa13ebdR1-R221) [[2]](diffhunk://#diff-761baefa5aa5a8c50be451008cecb5aecbef7a16fa84b372e25935033f7d98f8R1-R87) [[3]](diffhunk://#diff-c5ae634a10c62dc824583997121c7b51f3cb434e6cecde248e1598681401c5e3R1-R240)
- **Recommended approach (Option B / Sub-Option A2):** Introduce a query parameter or alternate endpoint (`?format=full` or `/export/full`) to allow retrieval of the full resource-claim tree for round-trip export→import workflows, preserving Admin App functionality with minimal changes. [[1]](diffhunk://#diff-df457c08ca3eedb4d285373d0d174e5f248cb8bc350c9c085af983ce2fa13ebdR1-R221) [[2]](diffhunk://#diff-c5ae634a10c62dc824583997121c7b51f3cb434e6cecde248e1598681401c5e3R1-R240)

### Export→Import Workflow and Admin App Impact

- **Round-trip preservation:** The design highlights the importance of maintaining the ability to export a claim set, edit it, and re-import it with full configuration. The recommended approach ensures this workflow is preserved for Admin App users by providing access to the full export format via an explicit route.
- **Admin App migration notes:** Forward-looking guidance is provided for updating Admin App to use the new export endpoint when migrating to Admin API v3, requiring only a small service call change. [[1]](diffhunk://#diff-df457c08ca3eedb4d285373d0d174e5f248cb8bc350c9c085af983ce2fa13ebdR1-R221) [[2]](diffhunk://#diff-c5ae634a10c62dc824583997121c7b51f3cb434e6cecde248e1598681401c5e3R1-R240)

### Name Field Validation

- **Whitespace validation fix:** Documents the need to update validators for the claim set Name field to reject names consisting solely of blank characters, addressing a usability issue in create, import, and edit endpoints.

### Documentation and Out-of-Scope Items

- **Comprehensive documentation:** Adds detailed spike and design documents outlining the problem, context, evaluated options, and next steps, including references to migration utilities and out-of-scope clarifications. [[1]](diffhunk://#diff-761baefa5aa5a8c50be451008cecb5aecbef7a16fa84b372e25935033f7d98f8R1-R87) [[2]](diffhunk://#diff-df457c08ca3eedb4d285373d0d174e5f248cb8bc350c9c085af983ce2fa13ebdR1-R221) [[3]](diffhunk://#diff-c5ae634a10c62dc824583997121c7b51f3cb434e6cecde248e1598681401c5e3R1-R240)

---

**References:**  
[[1]](diffhunk://#diff-761baefa5aa5a8c50be451008cecb5aecbef7a16fa84b372e25935033f7d98f8R1-R87) [[2]](diffhunk://#diff-df457c08ca3eedb4d285373d0d174e5f248cb8bc350c9c085af983ce2fa13ebdR1-R221) [[3]](diffhunk://#diff-c5ae634a10c62dc824583997121c7b51f3cb434e6cecde248e1598681401c5e3R1-R240)