### PR TITLE
[ADMINAPI-1424] Fixes for refresh endpoints

### DIFF
--- a/Application/EdFi.Ods.AdminApi.UnitTests/Features/OdsInstances/RefreshEducationOrganizationsTests.cs
+++ b/Application/EdFi.Ods.AdminApi.UnitTests/Features/OdsInstances/RefreshEducationOrganizationsTests.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EdFi.Admin.DataAccess.Models;
 using EdFi.Ods.AdminApi.Common.Infrastructure.Context;
-using EdFi.Ods.AdminApi.Common.Infrastructure.Jobs;
 using EdFi.Ods.AdminApi.Common.Infrastructure.MultiTenancy;
 using EdFi.Ods.AdminApi.Features.OdsInstances;
 using EdFi.Ods.AdminApi.Infrastructure.Database.Queries;
@@ -27,7 +26,6 @@ public class RefreshEducationOrganizationsTests
     private IContextProvider<TenantConfiguration> _tenantConfigurationProvider = null!;
     private IGetOdsInstanceQuery _getOdsInstanceByIdQuery = null!;
     private ISchedulerFactory _schedulerFactory = null!;
-    private IJobStatusService _jobStatusService = null!;
 
     [SetUp]
     public void SetUp()
@@ -36,7 +34,6 @@ public class RefreshEducationOrganizationsTests
         _tenantConfigurationProvider = A.Fake<IContextProvider<TenantConfiguration>>();
         _getOdsInstanceByIdQuery = A.Fake<IGetOdsInstanceQuery>();
         _schedulerFactory = new TestSchedulerFactory(_scheduler);
-        _jobStatusService = A.Fake<IJobStatusService>();
     }
 
     [Test]
@@ -50,8 +47,7 @@ public class RefreshEducationOrganizationsTests
         // Act
         var result = await RefreshEducationOrganizations.RefreshAllEducationOrganizations(
             _schedulerFactory,
-            _tenantConfigurationProvider,
-            _jobStatusService);
+            _tenantConfigurationProvider);
 
         // Assert
         result.ShouldNotBeNull();
@@ -77,7 +73,6 @@ public class RefreshEducationOrganizationsTests
             _schedulerFactory,
             _getOdsInstanceByIdQuery,
             _tenantConfigurationProvider,
-            _jobStatusService,
             instanceId);
 
         // Assert

--- a/Application/EdFi.Ods.AdminApi.V3.UnitTests/Features/OdsInstances/RefreshEducationOrganizationsTests.cs
+++ b/Application/EdFi.Ods.AdminApi.V3.UnitTests/Features/OdsInstances/RefreshEducationOrganizationsTests.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EdFi.Admin.DataAccess.Models;
 using EdFi.Ods.AdminApi.Common.Infrastructure.Context;
-using EdFi.Ods.AdminApi.Common.Infrastructure.Jobs;
 using EdFi.Ods.AdminApi.Common.Infrastructure.MultiTenancy;
 using EdFi.Ods.AdminApi.V3.Features.DataStores;
 using EdFi.Ods.AdminApi.V3.Infrastructure.Database.Queries;
@@ -27,7 +26,6 @@ public class RefreshEducationOrganizationsTests
     private IContextProvider<TenantConfiguration> _tenantConfigurationProvider = null!;
     private IGetDataStoreQuery _getDataStoreQuery = null!;
     private ISchedulerFactory _schedulerFactory = null!;
-    private IJobStatusService _jobStatusService = null!;
 
     [SetUp]
     public void SetUp()
@@ -36,7 +34,6 @@ public class RefreshEducationOrganizationsTests
         _tenantConfigurationProvider = A.Fake<IContextProvider<TenantConfiguration>>();
         _getDataStoreQuery = A.Fake<IGetDataStoreQuery>();
         _schedulerFactory = new TestSchedulerFactory(_scheduler);
-        _jobStatusService = A.Fake<IJobStatusService>();
     }
 
     [Test]
@@ -49,8 +46,7 @@ public class RefreshEducationOrganizationsTests
         // Act
         var result = await RefreshEducationOrganizations.RefreshAllEducationOrganizations(
             _schedulerFactory,
-            _tenantConfigurationProvider,
-            _jobStatusService);
+            _tenantConfigurationProvider);
 
         // Assert
         result.ShouldNotBeNull();
@@ -74,7 +70,6 @@ public class RefreshEducationOrganizationsTests
             _schedulerFactory,
             _getDataStoreQuery,
             _tenantConfigurationProvider,
-            _jobStatusService,
             instanceId);
 
         // Assert

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - EdOrgs - Refresh By InstanceId.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - EdOrgs - Refresh By InstanceId.bru
@@ -74,18 +74,47 @@ script:post-response {
       expect(body.jobId).to.be.a("string");
   });
 
-  test("POST DataStores by ID EdOrgs Refresh: Response has status Pending", function () {
+  test("POST DataStores by ID EdOrgs Refresh: Response has message", function () {
       const body = res.getBody();
-      expect(body).to.have.property("status");
-      expect(body.status).to.equal("Pending");
+      expect(body).to.have.property("message");
+      expect(body.message).to.be.a("string");
   });
 
-  test("POST DataStores by ID EdOrgs Refresh: Response has createdAt", function () {
-      const body = res.getBody();
-      expect(body).to.have.property("createdAt");
-  });
+  const jobId = res.getBody().jobId;
+  bru.setVar("JobId", jobId);
 
-  bru.setVar("JobId", res.getBody().jobId);
+  // Poll until the job status record exists (not 404)
+  const axios = require('axios');
+  const API_URL = bru.getEnvVar("API_URL");
+  const TOKEN = bru.getEnvVar("TOKEN");
+
+  const axiosConfig = {
+    headers: { 'Authorization': `Bearer ${TOKEN}` },
+    validateStatus: () => true,
+    timeout: 10000
+  };
+
+  if (bru.getEnvVar("isMultitenant") == "true") {
+    axiosConfig.headers['Tenant'] = bru.getEnvVar("tenant1");
+  }
+
+  let jobFound = false;
+  const maxAttempts = 10;
+  for (let i = 0; i < maxAttempts; i++) {
+    const r = await axios.get(`${API_URL}/v3/jobs/${jobId}`, axiosConfig);
+    if (r.status !== 404) {
+      console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
+      jobFound = true;
+      break;
+    }
+    if (i < maxAttempts - 1) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+
+  test("POST DataStores by ID EdOrgs Refresh: Job is accessible via GET /jobs/{jobId}", function () {
+    expect(jobFound).to.be.true;
+  });
 }
 
 settings {

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - EdOrgs - Refresh By InstanceId.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - EdOrgs - Refresh By InstanceId.bru
@@ -102,10 +102,12 @@ script:post-response {
   const maxAttempts = 10;
   for (let i = 0; i < maxAttempts; i++) {
     const r = await axios.get(`${API_URL}/v3/jobs/${jobId}`, axiosConfig);
-    if (r.status !== 404) {
+    if (r.status >= 200 && r.status < 300) {
       console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
       jobFound = true;
       break;
+    } else if (r.status !== 404) {
+      throw new Error(`Unexpected status ${r.status} while polling for job ${jobId}`);
     }
     if (i < maxAttempts - 1) {
       await new Promise(resolve => setTimeout(resolve, 1000));

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - EdOrgs - Refresh.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - EdOrgs - Refresh.bru
@@ -21,18 +21,47 @@ script:post-response {
       expect(body.jobId).to.be.a("string");
   });
 
-  test("POST DataStores EdOrgs Refresh: Response has status Pending", function () {
+  test("POST DataStores EdOrgs Refresh: Response has message", function () {
       const body = res.getBody();
-      expect(body).to.have.property("status");
-      expect(body.status).to.equal("Pending");
+      expect(body).to.have.property("message");
+      expect(body.message).to.be.a("string");
   });
 
-  test("POST DataStores EdOrgs Refresh: Response has createdAt", function () {
-      const body = res.getBody();
-      expect(body).to.have.property("createdAt");
-  });
+  const jobId = res.getBody().jobId;
+  bru.setVar("JobId", jobId);
 
-  bru.setVar("JobId", res.getBody().jobId);
+  // Poll until the job status record exists (not 404)
+  const axios = require('axios');
+  const API_URL = bru.getEnvVar("API_URL");
+  const TOKEN = bru.getEnvVar("TOKEN");
+
+  const axiosConfig = {
+    headers: { 'Authorization': `Bearer ${TOKEN}` },
+    validateStatus: () => true,
+    timeout: 10000
+  };
+
+  if (bru.getEnvVar("isMultitenant") == "true") {
+    axiosConfig.headers['Tenant'] = bru.getEnvVar("tenant1");
+  }
+
+  let jobFound = false;
+  const maxAttempts = 10;
+  for (let i = 0; i < maxAttempts; i++) {
+    const r = await axios.get(`${API_URL}/v3/jobs/${jobId}`, axiosConfig);
+    if (r.status !== 404) {
+      console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
+      jobFound = true;
+      break;
+    }
+    if (i < maxAttempts - 1) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+
+  test("POST DataStores EdOrgs Refresh: Job is accessible via GET /jobs/{jobId}", function () {
+    expect(jobFound).to.be.true;
+  });
 }
 
 settings {

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - EdOrgs - Refresh.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - EdOrgs - Refresh.bru
@@ -49,10 +49,12 @@ script:post-response {
   const maxAttempts = 10;
   for (let i = 0; i < maxAttempts; i++) {
     const r = await axios.get(`${API_URL}/v3/jobs/${jobId}`, axiosConfig);
-    if (r.status !== 404) {
+    if (r.status >= 200 && r.status < 300) {
       console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
       jobFound = true;
       break;
+    } else if (r.status !== 404) {
+      throw new Error(`Unexpected status ${r.status} while polling for job ${jobId}`);
     }
     if (i < maxAttempts - 1) {
       await new Promise(resolve => setTimeout(resolve, 1000));

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Jobs/GET - Job Status by ID.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Jobs/GET - Job Status by ID.bru
@@ -44,10 +44,12 @@ script:pre-request {
   const maxAttempts = 10;
   for (let i = 0; i < maxAttempts; i++) {
     const r = await axios.get(`${API_URL}/v3/jobs/${jobId}`, axiosConfig);
-    if (r.status !== 404) {
+    if (r.status >= 200 && r.status < 300) {
       console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
       jobFound = true;
       break;
+    } else if (r.status !== 404) {
+      throw new Error(`Unexpected status ${r.status} while polling for job ${jobId}`);
     }
     if (i < maxAttempts - 1) {
       await new Promise(resolve => setTimeout(resolve, 1000));

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Jobs/GET - Job Status by ID.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Jobs/GET - Job Status by ID.bru
@@ -10,6 +10,55 @@ get {
   auth: inherit
 }
 
+script:pre-request {
+  // Trigger a refresh to ensure a valid JobId is available before the main request
+  const axios = require('axios');
+  const API_URL = bru.getEnvVar("API_URL");
+  const TOKEN = bru.getEnvVar("TOKEN");
+
+  const axiosConfig = {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${TOKEN}`
+    },
+    validateStatus: () => true,
+    timeout: 30000
+  };
+
+  if (bru.getEnvVar("isMultitenant") == "true") {
+    axiosConfig.headers['Tenant'] = bru.getEnvVar("tenant1");
+  }
+
+  const refreshResponse = await axios.post(`${API_URL}/v3/dataStores/edOrgs/refresh`, null, axiosConfig);
+
+  test("Pre: Refresh endpoint returns 201", function () {
+    expect(refreshResponse.status).to.equal(201);
+  });
+
+  const jobId = refreshResponse.data.jobId;
+  bru.setVar("JobId", jobId);
+  console.log(`✅ Triggered refresh job: ${jobId}`);
+
+  // Poll until the job status record exists (not 404)
+  let jobFound = false;
+  const maxAttempts = 10;
+  for (let i = 0; i < maxAttempts; i++) {
+    const r = await axios.get(`${API_URL}/v3/jobs/${jobId}`, axiosConfig);
+    if (r.status !== 404) {
+      console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
+      jobFound = true;
+      break;
+    }
+    if (i < maxAttempts - 1) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+
+  test("Pre: Job is accessible via GET /jobs/{jobId} before main request", function () {
+    expect(jobFound).to.be.true;
+  });
+}
+
 script:post-response {
   test("GET Job Status: Status code is OK", function () {
     expect(res.getStatus()).to.equal(200);

--- a/Application/EdFi.Ods.AdminApi.V3/Features/DataStores/RefreshEducationOrganizations.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Features/DataStores/RefreshEducationOrganizations.cs
@@ -43,8 +43,7 @@ public class RefreshEducationOrganizations : IFeature
 
     public static async Task<IResult> RefreshAllEducationOrganizations(
         [FromServices] ISchedulerFactory schedulerFactory,
-        [FromServices] IContextProvider<TenantConfiguration> tenantConfigurationProvider,
-        [FromServices] IJobStatusService jobStatusService)
+        [FromServices] IContextProvider<TenantConfiguration> tenantConfigurationProvider)
     {
         var tenantConfiguration = tenantConfigurationProvider.Get();
         var tenantIdentifier = tenantConfiguration?.TenantIdentifier;
@@ -65,14 +64,9 @@ public class RefreshEducationOrganizations : IFeature
         var scheduler = await schedulerFactory.GetScheduler();
         await scheduler.ScheduleJob(job, trigger);
 
-        await jobStatusService.SetStatusAsync(jobId, QuartzJobStatus.Pending, tenantIdentifier);
-
-        var createdAt = DateTime.UtcNow;
         var response = new
         {
             jobId,
-            status = QuartzJobStatus.Pending.ToString(),
-            createdAt,
             message = "Education organizations refresh has been queued for all instances"
         };
         var locationUri = $"/v3/jobs/{jobId}";
@@ -84,7 +78,6 @@ public class RefreshEducationOrganizations : IFeature
         [FromServices] ISchedulerFactory schedulerFactory,
         [FromServices] IGetDataStoreQuery getDataStoreQuery,
         [FromServices] IContextProvider<TenantConfiguration> tenantConfigurationProvider,
-        [FromServices] IJobStatusService jobStatusService,
         int dataStoreId)
     {
         var dataStore = getDataStoreQuery.Execute(dataStoreId);
@@ -113,14 +106,9 @@ public class RefreshEducationOrganizations : IFeature
         var scheduler = await schedulerFactory.GetScheduler();
         await scheduler.ScheduleJob(job, trigger);
 
-        await jobStatusService.SetStatusAsync(jobId, QuartzJobStatus.Pending, tenantIdentifier);
-
-        var createdAt = DateTime.UtcNow;
         var response = new
         {
             jobId,
-            status = QuartzJobStatus.Pending.ToString(),
-            createdAt,
             message = "Education organizations refresh has been queued for the specified instance"
         };
         var locationUri = $"/v3/jobs/{jobId}";

--- a/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/Jobs/GET - Job Status by ID.bru
+++ b/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/Jobs/GET - Job Status by ID.bru
@@ -44,10 +44,12 @@ script:pre-request {
   const maxAttempts = 10;
   for (let i = 0; i < maxAttempts; i++) {
     const r = await axios.get(`${API_URL}/v2/jobs/${jobId}`, axiosConfig);
-    if (r.status !== 404) {
+    if (r.status >= 200 && r.status < 300) {
       console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
       jobFound = true;
       break;
+    } else if (r.status !== 404) {
+      throw new Error(`Unexpected status ${r.status} while polling for job ${jobId}`);
     }
     if (i < maxAttempts - 1) {
       await new Promise(resolve => setTimeout(resolve, 1000));

--- a/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/Jobs/GET - Job Status by ID.bru
+++ b/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/Jobs/GET - Job Status by ID.bru
@@ -10,6 +10,55 @@ get {
   auth: inherit
 }
 
+script:pre-request {
+  // Trigger a refresh to ensure a valid JobId is available before the main request
+  const axios = require('axios');
+  const API_URL = bru.getEnvVar("API_URL");
+  const TOKEN = bru.getEnvVar("TOKEN");
+
+  const axiosConfig = {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${TOKEN}`
+    },
+    validateStatus: () => true,
+    timeout: 30000
+  };
+
+  if (bru.getEnvVar("isMultitenant") == "true") {
+    axiosConfig.headers['Tenant'] = bru.getEnvVar("tenant1");
+  }
+
+  const refreshResponse = await axios.post(`${API_URL}/v2/odsInstances/edOrgs/refresh`, null, axiosConfig);
+
+  test("Pre: Refresh endpoint returns 201", function () {
+    expect(refreshResponse.status).to.equal(201);
+  });
+
+  const jobId = refreshResponse.data.jobId;
+  bru.setVar("JobId", jobId);
+  console.log(`✅ Triggered refresh job: ${jobId}`);
+
+  // Poll until the job status record exists (not 404)
+  let jobFound = false;
+  const maxAttempts = 10;
+  for (let i = 0; i < maxAttempts; i++) {
+    const r = await axios.get(`${API_URL}/v2/jobs/${jobId}`, axiosConfig);
+    if (r.status !== 404) {
+      console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
+      jobFound = true;
+      break;
+    }
+    if (i < maxAttempts - 1) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+
+  test("Pre: Job is accessible via GET /jobs/{jobId} before main request", function () {
+    expect(jobFound).to.be.true;
+  });
+}
+
 script:post-response {
   test("GET Job Status: Status code is OK", function () {
     expect(res.getStatus()).to.equal(200);

--- a/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/OdsInstances/POST - OdsInstances - EdOrgs - Refresh By InstanceId.bru
+++ b/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/OdsInstances/POST - OdsInstances - EdOrgs - Refresh By InstanceId.bru
@@ -74,18 +74,47 @@ script:post-response {
       expect(body.jobId).to.be.a("string");
   });
 
-  test("POST OdsInstances by ID EdOrgs Refresh: Response has status Pending", function () {
+  test("POST OdsInstances by ID EdOrgs Refresh: Response has message", function () {
       const body = res.getBody();
-      expect(body).to.have.property("status");
-      expect(body.status).to.equal("Pending");
+      expect(body).to.have.property("message");
+      expect(body.message).to.be.a("string");
   });
 
-  test("POST OdsInstances by ID EdOrgs Refresh: Response has createdAt", function () {
-      const body = res.getBody();
-      expect(body).to.have.property("createdAt");
-  });
+  const jobId = res.getBody().jobId;
+  bru.setVar("JobId", jobId);
 
-  bru.setVar("JobId", res.getBody().jobId);
+  // Poll until the job status record exists (not 404)
+  const axios = require('axios');
+  const API_URL = bru.getEnvVar("API_URL");
+  const TOKEN = bru.getEnvVar("TOKEN");
+
+  const axiosConfig = {
+    headers: { 'Authorization': `Bearer ${TOKEN}` },
+    validateStatus: () => true,
+    timeout: 10000
+  };
+
+  if (bru.getEnvVar("isMultitenant") == "true") {
+    axiosConfig.headers['Tenant'] = bru.getEnvVar("tenant1");
+  }
+
+  let jobFound = false;
+  const maxAttempts = 10;
+  for (let i = 0; i < maxAttempts; i++) {
+    const r = await axios.get(`${API_URL}/v2/jobs/${jobId}`, axiosConfig);
+    if (r.status !== 404) {
+      console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
+      jobFound = true;
+      break;
+    }
+    if (i < maxAttempts - 1) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+
+  test("POST OdsInstances by ID EdOrgs Refresh: Job is accessible via GET /jobs/{jobId}", function () {
+    expect(jobFound).to.be.true;
+  });
 }
 
 settings {

--- a/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/OdsInstances/POST - OdsInstances - EdOrgs - Refresh By InstanceId.bru
+++ b/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/OdsInstances/POST - OdsInstances - EdOrgs - Refresh By InstanceId.bru
@@ -102,10 +102,12 @@ script:post-response {
   const maxAttempts = 10;
   for (let i = 0; i < maxAttempts; i++) {
     const r = await axios.get(`${API_URL}/v2/jobs/${jobId}`, axiosConfig);
-    if (r.status !== 404) {
+    if (r.status >= 200 && r.status < 300) {
       console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
       jobFound = true;
       break;
+    } else if (r.status !== 404) {
+      throw new Error(`Unexpected status ${r.status} while polling for job ${jobId}`);
     }
     if (i < maxAttempts - 1) {
       await new Promise(resolve => setTimeout(resolve, 1000));

--- a/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/OdsInstances/POST - OdsInstances - EdOrgs - Refresh.bru
+++ b/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/OdsInstances/POST - OdsInstances - EdOrgs - Refresh.bru
@@ -21,18 +21,47 @@ script:post-response {
       expect(body.jobId).to.be.a("string");
   });
 
-  test("POST OdsInstances EdOrgs Refresh: Response has status Pending", function () {
+  test("POST OdsInstances EdOrgs Refresh: Response has message", function () {
       const body = res.getBody();
-      expect(body).to.have.property("status");
-      expect(body.status).to.equal("Pending");
+      expect(body).to.have.property("message");
+      expect(body.message).to.be.a("string");
   });
 
-  test("POST OdsInstances EdOrgs Refresh: Response has createdAt", function () {
-      const body = res.getBody();
-      expect(body).to.have.property("createdAt");
-  });
+  const jobId = res.getBody().jobId;
+  bru.setVar("JobId", jobId);
 
-  bru.setVar("JobId", res.getBody().jobId);
+  // Poll until the job status record exists (not 404)
+  const axios = require('axios');
+  const API_URL = bru.getEnvVar("API_URL");
+  const TOKEN = bru.getEnvVar("TOKEN");
+
+  const axiosConfig = {
+    headers: { 'Authorization': `Bearer ${TOKEN}` },
+    validateStatus: () => true,
+    timeout: 10000
+  };
+
+  if (bru.getEnvVar("isMultitenant") == "true") {
+    axiosConfig.headers['Tenant'] = bru.getEnvVar("tenant1");
+  }
+
+  let jobFound = false;
+  const maxAttempts = 10;
+  for (let i = 0; i < maxAttempts; i++) {
+    const r = await axios.get(`${API_URL}/v2/jobs/${jobId}`, axiosConfig);
+    if (r.status !== 404) {
+      console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
+      jobFound = true;
+      break;
+    }
+    if (i < maxAttempts - 1) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+
+  test("POST OdsInstances EdOrgs Refresh: Job is accessible via GET /jobs/{jobId}", function () {
+    expect(jobFound).to.be.true;
+  });
 }
 
 settings {

--- a/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/OdsInstances/POST - OdsInstances - EdOrgs - Refresh.bru
+++ b/Application/EdFi.Ods.AdminApi/E2E Tests/V2/Bruno Admin API E2E 2.0 refactor/v2/OdsInstances/POST - OdsInstances - EdOrgs - Refresh.bru
@@ -49,10 +49,12 @@ script:post-response {
   const maxAttempts = 10;
   for (let i = 0; i < maxAttempts; i++) {
     const r = await axios.get(`${API_URL}/v2/jobs/${jobId}`, axiosConfig);
-    if (r.status !== 404) {
+    if (r.status >= 200 && r.status < 300) {
       console.log(`✅ Job ${jobId} found after ${i + 1} attempt(s)`);
       jobFound = true;
       break;
+    } else if (r.status !== 404) {
+      throw new Error(`Unexpected status ${r.status} while polling for job ${jobId}`);
     }
     if (i < maxAttempts - 1) {
       await new Promise(resolve => setTimeout(resolve, 1000));

--- a/Application/EdFi.Ods.AdminApi/Features/OdsInstances/RefreshEducationOrganizations.cs
+++ b/Application/EdFi.Ods.AdminApi/Features/OdsInstances/RefreshEducationOrganizations.cs
@@ -43,8 +43,7 @@ public class RefreshEducationOrganizations : IFeature
 
     public static async Task<IResult> RefreshAllEducationOrganizations(
         [FromServices] ISchedulerFactory schedulerFactory,
-        [FromServices] IContextProvider<TenantConfiguration> tenantConfigurationProvider,
-        [FromServices] IJobStatusService jobStatusService)
+        [FromServices] IContextProvider<TenantConfiguration> tenantConfigurationProvider)
     {
         var tenantConfiguration = tenantConfigurationProvider.Get();
         var tenantIdentifier = tenantConfiguration?.TenantIdentifier;
@@ -65,14 +64,9 @@ public class RefreshEducationOrganizations : IFeature
         var scheduler = await schedulerFactory.GetScheduler();
         await scheduler.ScheduleJob(job, trigger);
 
-        await jobStatusService.SetStatusAsync(jobId, QuartzJobStatus.Pending, tenantIdentifier);
-
-        var createdAt = DateTime.UtcNow;
         var response = new
         {
             jobId,
-            status = QuartzJobStatus.Pending.ToString(),
-            createdAt,
             message = "Education organizations refresh has been queued for all instances"
         };
         var locationUri = $"/v2/jobs/{jobId}";
@@ -84,7 +78,6 @@ public class RefreshEducationOrganizations : IFeature
         [FromServices] ISchedulerFactory schedulerFactory,
         [FromServices] IGetOdsInstanceQuery getOdsInstanceByIdQuery,
         [FromServices] IContextProvider<TenantConfiguration> tenantConfigurationProvider,
-        [FromServices] IJobStatusService jobStatusService,
         int instanceId)
     {
         var odsInstance = getOdsInstanceByIdQuery.Execute(instanceId);
@@ -113,14 +106,9 @@ public class RefreshEducationOrganizations : IFeature
         var scheduler = await schedulerFactory.GetScheduler();
         await scheduler.ScheduleJob(job, trigger);
 
-        await jobStatusService.SetStatusAsync(jobId, QuartzJobStatus.Pending, tenantIdentifier);
-
-        var createdAt = DateTime.UtcNow;
         var response = new
         {
             jobId,
-            status = QuartzJobStatus.Pending.ToString(),
-            createdAt,
             message = "Education organizations refresh has been queued for the specified instance"
         };
         var locationUri = $"/v2/jobs/{jobId}";

--- a/Docker/Settings/V2/gateway/Dockerfile
+++ b/Docker/Settings/V2/gateway/Dockerfile
@@ -7,6 +7,8 @@
 FROM nginx@sha256:2140dad235c130ac861018a4e13a6bc8aea3a35f3a40e20c1b060d51a7efd250
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
+RUN apk add --no-cache openssl=3.3.7-r0
+
 COPY ./default.conf.template /etc/nginx/templates/
 
 EXPOSE 443

--- a/Docker/Settings/V2/gateway/IDP.Dockerfile
+++ b/Docker/Settings/V2/gateway/IDP.Dockerfile
@@ -11,6 +11,8 @@
 FROM nginx@sha256:2140dad235c130ac861018a4e13a6bc8aea3a35f3a40e20c1b060d51a7efd250
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
+RUN apk add --no-cache openssl=3.3.7-r0
+
 COPY ./default_idp.conf.template /etc/nginx/templates/default.conf.template
 
 EXPOSE 443

--- a/Docker/Settings/shared/gateway/IDP.Dockerfile
+++ b/Docker/Settings/shared/gateway/IDP.Dockerfile
@@ -11,6 +11,8 @@
 FROM nginx@sha256:2140dad235c130ac861018a4e13a6bc8aea3a35f3a40e20c1b060d51a7efd250
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
+RUN apk add --no-cache openssl=3.3.7-r0
+
 COPY ./default_idp.conf.template /etc/nginx/templates/default.conf.template
 
 EXPOSE 443

--- a/Docker/api.mssql.Dockerfile
+++ b/Docker/api.mssql.Dockerfile
@@ -5,7 +5,7 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.22-amd64@sha256:86b43b7250c683781587f9e8d30a2315c5684f1b1fb788a9aa74e86bc06df4a5 AS base
 RUN apk upgrade --no-cache && \
-    apk add --no-cache unzip=~6 dos2unix=~7 bash=~5 gettext=~0 jq=~1 icu=~76.1-r1 openssl=3.5.6-r0 musl=~1.2.5-r12 && \
+    apk add --no-cache unzip=~6 dos2unix=~7 bash=~5 gettext=~0 jq=~1 icu=~76.1-r1 krb5-libs=~1 openssl=3.5.6-r0 musl=~1.2.5-r12 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 
 FROM base AS build

--- a/Docker/api.pgsql.Dockerfile
+++ b/Docker/api.pgsql.Dockerfile
@@ -6,7 +6,7 @@
 #tag 10.0-alpine
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.22@sha256:86b43b7250c683781587f9e8d30a2315c5684f1b1fb788a9aa74e86bc06df4a5 AS base
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash=~5 dos2unix=~7 gettext=~0 icu=~76.1-r1 jq=~1 musl=~1.2.5-r12 openssl=3.5.6-r0 postgresql15-client=~15 unzip=~6 && \
+    apk add --no-cache bash=~5 dos2unix=~7 gettext=~0 icu=~76.1-r1 jq=~1 krb5-libs=~1 musl=~1.2.5-r12 openssl=3.5.6-r0 postgresql15-client=~15 unzip=~6 && \
     rm -rf /var/cache/apk/* && \
     addgroup -S edfi && adduser -S edfi -G edfi
 

--- a/Docker/dev.mssql.Dockerfile
+++ b/Docker/dev.mssql.Dockerfile
@@ -32,7 +32,7 @@ RUN dotnet publish -c Release /p:EnvironmentName=$ASPNETCORE_ENVIRONMENT --no-bu
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.22-amd64@sha256:86b43b7250c683781587f9e8d30a2315c5684f1b1fb788a9aa74e86bc06df4a5 AS runtimebase
 RUN apk upgrade --no-cache && \
-    apk add dos2unix=~7 bash=~5 gettext=~0 icu=~76.1-r1 curl openssl=3.5.6-r0 musl=~1.2.5-r12 && \
+    apk add dos2unix=~7 bash=~5 gettext=~0 icu=~76.1-r1 krb5-libs=~1 curl openssl=3.5.6-r0 musl=~1.2.5-r12 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 
 FROM runtimebase AS setup

--- a/Docker/dev.pgsql.Dockerfile
+++ b/Docker/dev.pgsql.Dockerfile
@@ -11,7 +11,7 @@
 FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601 AS assets
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.22@sha256:ddae163c8bd4d12df3bd767bdea4afc248abfd1148cdbb8ac549fa80bbb397dc AS build
-RUN apk add --no-cache musl=1.2.5-r12 && \
+RUN apk add --no-cache musl=~1.2.5-r12 && \
     rm -rf /var/cache/apk/*
 
 ARG ASPNETCORE_ENVIRONMENT=Production
@@ -44,7 +44,7 @@ RUN apk add --no-cache \
         gettext=~0 \
         icu=~76.1-r1 \
         krb5-libs=~1 \
-        musl=1.2.5-r12 \
+        musl=~1.2.5-r12 \
         openssl=3.5.6-r0 \
         postgresql15-client=15.18-r0 && \
     rm -rf /var/cache/apk/* && \

--- a/Docker/dev.pgsql.Dockerfile
+++ b/Docker/dev.pgsql.Dockerfile
@@ -43,6 +43,7 @@ RUN apk add --no-cache \
         dos2unix=~7 \
         gettext=~0 \
         icu=~76.1-r1 \
+        krb5-libs=~1 \
         musl=~1.2.5-r12 \
         openssl=3.5.6-r0 \
         postgresql15-client=15.18-r0 && \

--- a/Docker/dev.pgsql.Dockerfile
+++ b/Docker/dev.pgsql.Dockerfile
@@ -11,7 +11,7 @@
 FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601 AS assets
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.22@sha256:ddae163c8bd4d12df3bd767bdea4afc248abfd1148cdbb8ac549fa80bbb397dc AS build
-RUN apk add --no-cache musl=~1.2.5-r12 && \
+RUN apk add --no-cache musl=1.2.5-r12 && \
     rm -rf /var/cache/apk/*
 
 ARG ASPNETCORE_ENVIRONMENT=Production
@@ -44,7 +44,7 @@ RUN apk add --no-cache \
         gettext=~0 \
         icu=~76.1-r1 \
         krb5-libs=~1 \
-        musl=~1.2.5-r12 \
+        musl=1.2.5-r12 \
         openssl=3.5.6-r0 \
         postgresql15-client=15.18-r0 && \
     rm -rf /var/cache/apk/* && \


### PR DESCRIPTION
Fixes issues on the education organization refresh endpoints for V2 (/odsInstances/edOrgs/refresh) and V3 (/dataStores/edOrgs/refresh):

Problem

When multiple requests were made to the refresh endpoints, a duplicate key constraint violation was thrown (uq_jobstatuses_jobid). This was caused by a race condition: the endpoint called SetStatusAsync(Pending) after scheduling the Quartz job with StartNow(), allowing the job to begin executing and INSERT a status record concurrently.

Changes

C# — Refresh endpoints (V2 & V3):

 - Removed IJobStatusService dependency and SetStatusAsync(Pending) call from all refresh endpoint handlers — the job's AdminApiQuartzJobBase.Execute() is solely responsible for writing status records (InProgress, Completed, Error)
 - Removed status and createdAt from the refresh response body; now returns only jobId and message

Bruno E2E Tests (V2 & V3):

 - Updated refresh test assertions to reflect the new response shape (removed status/createdAt checks, added message check)
 - Added polling post-script to refresh tests: after triggering a refresh, polls GET /jobs/{jobId} until the record exists (not 404), asserted as a test case
 - Added script:pre-request to GET - Job Status by ID tests: triggers a fresh refresh and polls until the job is accessible before the main request, with test case assertions