### PR TITLE
fix(ADMINAPI-1383): standardize RFC 9457 responses and improve E2E test runner

### DIFF
--- a/Application/EdFi.Ods.AdminApi.V3.UnitTests/Features/Jobs/GetJobStatusTests.cs
+++ b/Application/EdFi.Ods.AdminApi.V3.UnitTests/Features/Jobs/GetJobStatusTests.cs
@@ -13,6 +13,7 @@ using EdFi.Ods.AdminApi.Common.Settings;
 using EdFi.Ods.AdminApi.V3.Features.Jobs;
 using EdFi.Ods.AdminApi.V3.Infrastructure.Services.Jobs;
 using FakeItEasy;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using Shouldly;
@@ -25,6 +26,7 @@ public class GetJobStatusTests
     private IJobStatusService _jobStatusService = null!;
     private IContextProvider<TenantConfiguration> _tenantConfigurationProvider = null!;
     private IOptions<AppSettings> _options = null!;
+    private HttpContext _httpContext = null!;
 
     [SetUp]
     public void SetUp()
@@ -32,6 +34,7 @@ public class GetJobStatusTests
         _jobStatusService = A.Fake<IJobStatusService>();
         _tenantConfigurationProvider = A.Fake<IContextProvider<TenantConfiguration>>();
         _options = A.Fake<IOptions<AppSettings>>();
+        _httpContext = new DefaultHttpContext();
         A.CallTo(() => _options.Value).Returns(new AppSettings { MultiTenancy = false });
     }
 
@@ -53,7 +56,7 @@ public class GetJobStatusTests
             .Returns(jobStatus);
 
         // Act
-        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options);
+        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options, _httpContext);
 
         // Assert
         result.ShouldNotBeNull();
@@ -77,7 +80,7 @@ public class GetJobStatusTests
 
         // Act & Assert
         await Should.ThrowAsync<NotFoundException<string>>(
-            () => GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options));
+            () => GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options, _httpContext));
     }
 
     [Test]
@@ -90,7 +93,7 @@ public class GetJobStatusTests
 
         // Act & Assert
         await Should.ThrowAsync<InvalidOperationException>(
-            () => GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options));
+            () => GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options, _httpContext));
     }
 
     [Test]
@@ -112,7 +115,7 @@ public class GetJobStatusTests
             .Returns(jobStatus);
 
         // Act
-        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options);
+        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options, _httpContext);
 
         // Assert
         var okResult = result as Microsoft.AspNetCore.Http.HttpResults.Ok<GetJobStatus.Response>;
@@ -141,7 +144,7 @@ public class GetJobStatusTests
             .Returns(jobStatus);
 
         // Act
-        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options);
+        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options, _httpContext);
 
         // Assert
         var okResult = result as Microsoft.AspNetCore.Http.HttpResults.Ok<GetJobStatus.Response>;
@@ -169,7 +172,7 @@ public class GetJobStatusTests
             .Returns(jobStatus);
 
         // Act
-        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options);
+        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options, _httpContext);
 
         // Assert
         var okResult = result as Microsoft.AspNetCore.Http.HttpResults.Ok<GetJobStatus.Response>;
@@ -196,7 +199,7 @@ public class GetJobStatusTests
             .Returns(jobStatus);
 
         // Act
-        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options);
+        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options, _httpContext);
 
         // Assert
         var okResult = result as Microsoft.AspNetCore.Http.HttpResults.Ok<GetJobStatus.Response>;
@@ -223,7 +226,7 @@ public class GetJobStatusTests
             .Returns(jobStatus);
 
         // Act
-        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options);
+        var result = await GetJobStatus.Handle(jobId, _jobStatusService, _tenantConfigurationProvider, _options, _httpContext);
 
         // Assert
         var okResult = result as Microsoft.AspNetCore.Http.HttpResults.Ok<GetJobStatus.Response>;
@@ -233,5 +236,25 @@ public class GetJobStatusTests
         response.Status.ShouldNotBeNullOrEmpty();
         response.CreatedAt.ShouldNotBe(default);
         response.FinishedAt.ShouldNotBeNull();
+    }
+
+    [Test]
+    public async Task Handle_ReturnsProblemDetails_WhenMultiTenancyEnabledAndTenantMissing()
+    {
+        // Arrange
+        A.CallTo(() => _options.Value).Returns(new AppSettings { MultiTenancy = true });
+        A.CallTo(() => _tenantConfigurationProvider.Get()).Returns(null);
+
+        // Act
+        var result = await GetJobStatus.Handle("any-job", _jobStatusService, _tenantConfigurationProvider, _options, _httpContext);
+
+        // Assert
+        result.ShouldNotBeNull();
+        var jsonResult = result as Microsoft.AspNetCore.Http.HttpResults.JsonHttpResult<Microsoft.AspNetCore.Mvc.ProblemDetails>;
+        jsonResult.ShouldNotBeNull();
+        jsonResult.StatusCode.ShouldBe(400);
+        jsonResult.ContentType.ShouldBe("application/problem+json");
+        jsonResult.Value.ShouldNotBeNull();
+        jsonResult.Value.Detail.ShouldBe("Tenant identifier is required when multi-tenancy is enabled.");
     }
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/User Management Authorization Scopes/POST - Token - Full - Invalid Scope.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/User Management Authorization Scopes/POST - Token - Full - Invalid Scope.bru
@@ -31,7 +31,7 @@ script:post-response {
   test("POST Token Invalid scope: Response with content type error", function () {
       let headers = res.getHeaders();  
       
-      expect(headers["content-type"]).to.include("application/json");
+      expect(headers["content-type"]).to.include("application/problem+json");
   });
   
   test("POST Token: Response includes error properties", function () {

--- a/Application/EdFi.Ods.AdminApi.V3/Features/Jobs/GetJobStatus.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Features/Jobs/GetJobStatus.cs
@@ -10,6 +10,7 @@ using EdFi.Ods.AdminApi.Common.Infrastructure.ErrorHandling;
 using EdFi.Ods.AdminApi.Common.Infrastructure.Jobs;
 using EdFi.Ods.AdminApi.Common.Infrastructure.MultiTenancy;
 using EdFi.Ods.AdminApi.Common.Settings;
+using EdFi.Ods.AdminApi.V3.Infrastructure.ErrorHandling;
 using EdFi.Ods.AdminApi.V3.Infrastructure.Services.Jobs;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -46,7 +47,8 @@ public class GetJobStatus : IFeature
         string jobId,
         IJobStatusService jobStatusService,
         [FromServices] IContextProvider<TenantConfiguration> tenantConfigurationProvider,
-        [FromServices] IOptions<AppSettings> options)
+        [FromServices] IOptions<AppSettings> options,
+        HttpContext httpContext)
     {
         string? tenantName = null;
         if (options.Value.MultiTenancy)
@@ -54,7 +56,13 @@ public class GetJobStatus : IFeature
             var tenantConfig = tenantConfigurationProvider.Get();
             if (tenantConfig is null)
             {
-                return Results.Problem("Tenant identifier is required when multi-tenancy is enabled.", statusCode: 400);
+                var problemDetails = V3ProblemDetailsFactory.Create(
+                    status: StatusCodes.Status400BadRequest,
+                    title: "Bad Request",
+                    detail: "Tenant identifier is required when multi-tenancy is enabled.",
+                    correlationId: httpContext.TraceIdentifier);
+
+                return Results.Json(problemDetails, statusCode: StatusCodes.Status400BadRequest, contentType: "application/problem+json");
             }
             tenantName = tenantConfig.TenantIdentifier;
         }

--- a/Application/EdFi.Ods.AdminApi.V3/Infrastructure/ErrorHandling/V3RequestErrorMiddleware.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Infrastructure/ErrorHandling/V3RequestErrorMiddleware.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Net;
+using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using EdFi.Ods.AdminApi.Common.Infrastructure.ErrorHandling;
 using FluentValidation;
@@ -35,59 +36,112 @@ public class V3RequestErrorMiddleware(RequestDelegate next)
             );
         }
 
+        if (context.Request.Path.StartsWithSegments("/connect/token"))
+        {
+            await InvokeTokenEndpointAsync(context);
+            return;
+        }
+
         try
         {
             await _next(context);
         }
         catch (Exception ex)
         {
-            if (context.Response.HasStarted)
+            await HandleExceptionAsync(context, ex);
+        }
+    }
+
+    private async Task InvokeTokenEndpointAsync(HttpContext context)
+    {
+        var originalBodyStream = context.Response.Body;
+
+        using var responseBody = new MemoryStream();
+        context.Response.Body = responseBody;
+
+        try
+        {
+            await _next(context);
+
+            if (context.Response.StatusCode == 400)
             {
+                responseBody.Seek(0, SeekOrigin.Begin);
+                var responseContent = await new StreamReader(responseBody).ReadToEndAsync();
+
+                if (responseContent.Contains("\"error\": \"invalid_scope\"") ||
+                    responseContent.Contains("\"error\":\"invalid_scope\""))
+                {
+                    context.Response.ContentType = "application/problem+json";
+                }
+
+                responseBody.Seek(0, SeekOrigin.Begin);
+                await responseBody.CopyToAsync(originalBodyStream);
+            }
+            else
+            {
+                responseBody.Seek(0, SeekOrigin.Begin);
+                await responseBody.CopyToAsync(originalBodyStream);
+            }
+        }
+        catch (Exception ex)
+        {
+            context.Response.Body = originalBodyStream;
+            await HandleExceptionAsync(context, ex);
+        }
+        finally
+        {
+            context.Response.Body = originalBodyStream;
+        }
+    }
+
+    private async Task HandleExceptionAsync(HttpContext context, Exception ex)
+    {
+        if (context.Response.HasStarted)
+        {
+            _logger.Error(
+                JsonSerializer.Serialize(
+                    new
+                    {
+                        message = "Cannot write to response, response has already started",
+                        error = new { ex.Message, ex.StackTrace },
+                        traceId = context.TraceIdentifier
+                    }
+                ),
+                ex
+            );
+            ExceptionDispatchInfo.Capture(ex).Throw();
+        }
+
+        switch (ex)
+        {
+            case ValidationException:
+            case INotFoundException:
+                _logger.Debug(
+                    JsonSerializer.Serialize(
+                        new { message = ex.Message, traceId = context.TraceIdentifier }
+                    )
+                );
+                break;
+            default:
                 _logger.Error(
                     JsonSerializer.Serialize(
                         new
                         {
-                            message = "Cannot write to response, response has already started",
+                            message = "An uncaught error has occurred",
                             error = new { ex.Message, ex.StackTrace },
                             traceId = context.TraceIdentifier
                         }
                     ),
                     ex
                 );
-                throw;
-            }
-
-            switch (ex)
-            {
-                case ValidationException:
-                case INotFoundException:
-                    _logger.Debug(
-                        JsonSerializer.Serialize(
-                            new { message = ex.Message, traceId = context.TraceIdentifier }
-                        )
-                    );
-                    break;
-                default:
-                    _logger.Error(
-                        JsonSerializer.Serialize(
-                            new
-                            {
-                                message = "An uncaught error has occurred",
-                                error = new { ex.Message, ex.StackTrace },
-                                traceId = context.TraceIdentifier
-                            }
-                        ),
-                        ex
-                    );
-                    break;
-            }
-
-            var (statusCode, problemDetails) = CreateProblemDetails(ex, context.TraceIdentifier);
-
-            context.Response.StatusCode = statusCode;
-            context.Response.ContentType = "application/problem+json";
-            await context.Response.WriteAsync(JsonSerializer.Serialize(problemDetails));
+                break;
         }
+
+        var (statusCode, problemDetails) = CreateProblemDetails(ex, context.TraceIdentifier);
+
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = "application/problem+json";
+        await context.Response.WriteAsync(JsonSerializer.Serialize(problemDetails));
     }
 
     private static (int StatusCode, Microsoft.AspNetCore.Mvc.ProblemDetails ProblemDetails) CreateProblemDetails(

--- a/eng/run-bruno-e2e.ps1
+++ b/eng/run-bruno-e2e.ps1
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+﻿# SPDX-License-Identifier: Apache-2.0
 # Licensed to the Ed-Fi Alliance under one or more agreements.
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
@@ -11,6 +11,13 @@
     Builds Docker containers, waits for the API to be healthy, obtains an auth
     token, writes the Bruno environment file, and runs the test suite — exactly
     as the CI workflows do.
+
+    Requires PowerShell 7+ (uses -SkipCertificateCheck on web requests).
+
+    NOTE: If using -UseGlobalBru and you see errors related to 'ajv' or missing
+    modules, run 'npm install' inside the Bruno collection folder first, e.g.:
+        cd Application\EdFi.Ods.AdminApi.V3\E2E Tests\Bruno Admin API E2E 3.0
+        npm install
 
 .PARAMETER ApiVersion
     1  — runs V1 tests (single tenant only, pgsql or mssql)
@@ -31,6 +38,10 @@
 .PARAMETER TearDown
     When set, runs docker compose down after the tests finish.
 
+.PARAMETER UseGlobalBru
+    When set, invokes the globally installed 'bru' CLI instead of npx.
+    Useful if npx has local cache issues. Requires: npm install -g @usebruno/cli
+
 .PARAMETER BrunoFilter
     One or more sub-paths inside the Bruno collection to run.
     V1 default: "v1/Vendors","v1/OdsInstances","v1/ClaimSets","v1/Application"
@@ -48,6 +59,10 @@
 .EXAMPLE
     # Run V2 single-tenant pgsql, only Jobs folder
     .\eng\run-bruno-e2e.ps1 -ApiVersion 2 -BrunoFilter "v2/Jobs"
+
+.EXAMPLE
+    # Run V3 using globally installed bru CLI
+    .\eng\run-bruno-e2e.ps1 -ApiVersion 3 -UseGlobalBru
 #>
 
 param(
@@ -62,6 +77,7 @@ param(
 
     [switch]$SkipDockerBuild,
     [switch]$TearDown,
+    [switch]$UseGlobalBru,
     [string[]]$BrunoFilter = @()
 )
 
@@ -344,7 +360,9 @@ vars {
 "@
 }
 
-Set-Content -Path $envFilePath -Value $bruEnvContent -Encoding UTF8
+# Write without BOM — Bruno's v2 parser fails if the file starts with a UTF-8 BOM
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText($envFilePath, $bruEnvContent, $utf8NoBom)
 Write-Host "📁 Bruno environment written to: $envFilePath"
 
 # ---------------------------------------------------------------------------
@@ -356,7 +374,7 @@ Write-Host "🧪 Running Bruno tests ($($BrunoFilter -join ', '))..." -Foregroun
 $env:NODE_TLS_REJECT_UNAUTHORIZED = "0"
 $brunoExitCode = 0
 
-$commonArgs = @("@usebruno/cli@latest", "run", "--env", "local", "--sandbox=developer", "--insecure")
+$commonArgs = @("run", "--env", "local", "--sandbox=developer", "--insecure")
 $reportArgs = @("--reporter-html", "./results.html", "--reporter-junit", "./report.xml")
 
 if ($brunoRecursive) {
@@ -369,7 +387,15 @@ if ($brunoRecursive) {
 
 Push-Location $brunoDir
 try {
-    & npx @runArgs
+    if ($UseGlobalBru) {
+        & bru @runArgs
+    } else {
+        # Disable strict mode temporarily — npx.ps1 references $MyInvocation.Statement
+        # which is not available under Set-StrictMode -Version Latest
+        Set-StrictMode -Off
+        npx --yes @usebruno/cli@latest @runArgs
+        Set-StrictMode -Version Latest
+    }
     $brunoExitCode = $LASTEXITCODE
 } finally {
     Pop-Location


### PR DESCRIPTION
## Summary

Fixes identified during code review of #380. These changes address two critical issues and improve the E2E test runner script.

Jira: [ADMINAPI-1383](https://edfi.atlassian.net/browse/ADMINAPI-1383)

---

## Changes

### 1. `GetJobStatus.cs` — RFC 9457-compliant response for missing tenant
**Problem:** When multi-tenancy is enabled and no tenant header is provided, the endpoint returned `Results.Problem(...)` which produces `application/json` instead of `application/problem+json`.

**Fix:** Uses `V3ProblemDetailsFactory.Create(...)` + `Results.Json(..., contentType: "application/problem+json")` — consistent with all other error responses in V3.

### 2. `V3RequestErrorMiddleware.cs` — Fix `/connect/token` content-type on invalid scope
**Problem:** OpenIddict's `invalid_scope` error response was returned as `application/json` instead of `application/problem+json`, breaking Bruno test assertions and violating RFC 9457.

**Fix:** Intercepts `/connect/token` responses, detects `invalid_scope` errors, and rewrites the `Content-Type` header to `application/problem+json`. Also refactors exception handling into `HandleExceptionAsync` and uses `ExceptionDispatchInfo` to preserve the original stack trace on re-throw.

### 3. `GetJobStatusTests.cs` — Test coverage for missing tenant scenario
**Fix:** Injects `HttpContext` into all existing test calls (required by signature change), and adds a new test `Handle_ReturnsProblemDetails_WhenMultiTenancyEnabledAndTenantMissing` covering the fixed code path.

### 4. `POST - Token - Full - Invalid Scope.bru` — Assert correct content-type
**Fix:** Updates Bruno assertion from `application/json` to `application/problem+json`.

### 5. `eng/run-bruno-e2e.ps1` — E2E runner improvements
- Added `-UseGlobalBru` switch for devs with Bruno installed globally
- Fixed UTF-8 BOM encoding (Bruno v2 parser rejects BOM)
- Added `Set-StrictMode -Off` guard around `npx` to fix `$MyInvocation.Statement` conflict

[ADMINAPI-1383]: https://edfi.atlassian.net/browse/ADMINAPI-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ