### PR TITLE
[ADMINAPI-1417] - DO NOT MERGE - SPIKE - Investigate database templates setup

### DIFF
--- a/Application/EdFi.Ods.AdminApi/appsettings.Development.json
+++ b/Application/EdFi.Ods.AdminApi/appsettings.Development.json
@@ -1,12 +1,16 @@
 {
     "AppSettings": {
-        "MultiTenancy": true,
-        "DatabaseEngine": "SqlServer",
+        "MultiTenancy": false,
+        "DatabaseEngine": "PostgreSql",
         "CreateDbInstancesSweepIntervalInMins": 5,
         "CreateDbInstancesMaxRetryAttempts": 3,
         "DeleteDbInstancesSweepIntervalInMins": 5,
         "DeleteDbInstancesMaxRetryAttempts": 3,
-        "IgnoresCertificateErrors": true
+        "IgnoresCertificateErrors": true,
+        "adminApiMode": "v2",
+        "EncryptionKey": "TDMyNH0lJmo7aDRnNXYoSmAwSXQpV09nbitHSWJTKn0=",
+        "SqlServerMinimalBakFile": "/var/opt/mssql/data/sql-backups/EdFi.Ods.Minimal.Template.bak",
+        "SqlServerSampleBakFile": "/var/opt/mssql/data/sql-backups/EdFi.Ods.Populated.Template.bak"
     },
     "AdminConsoleSettings": {
         "CorsSettings": {
@@ -24,12 +28,20 @@
         "RoleClaimAttribute": "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
         "AllowRegistration": true
     },
+    /// PGSQL:
     "ConnectionStrings": {
-        "EdFi_Admin": "Data Source=.\\;Initial Catalog=EdFi_Admin7;Integrated Security=True;Trusted_Connection=true;Encrypt=True;TrustServerCertificate=True",
-        "EdFi_Security": "Data Source=.\\;Initial Catalog=EdFi_Security7;Integrated Security=True;Trusted_Connection=true;Encrypt=True;TrustServerCertificate=True",
-        "EdFi_Ods": "host=localhost;port=5881;username=postgres;password=P@ssw0rd;database=EdFi_Admin;pooling=true",
-        "EdFi_Master": "host=localhost;port=5881;username=postgres;password=P@ssw0rd;database=postgres;pooling=true"
+        "EdFi_Admin": "host=localhost;port=5880;username=postgres;password=P@ssw0rd;database=EdFi_Admin;pooling=true",
+        "EdFi_Security": "host=localhost;port=5880;username=postgres;password=P@ssw0rd;database=EdFi_Security;pooling=true",
+        "EdFi_Ods": "host=localhost;port=5401;username=postgres;password=P@ssw0rd;database=EdFi_Ods;pooling=true",
+        "EdFi_Master": "host=localhost;port=5401;username=postgres;password=P@ssw0rd;database=postgres;pooling=true"
     },
+    /// MSSQL:
+    //"ConnectionStrings": {
+    //    "EdFi_Admin": "Data Source=localhost,1435;Initial Catalog=EdFi_Admin;Integrated Security=False;User Id=sa;Password=P@55w0rd;Encrypt=True;TrustServerCertificate=True",
+    //    "EdFi_Security": "Data Source=localhost,1435;Initial Catalog=EdFi_Security;Integrated Security=False;User Id=sa;Password=P@55w0rd;Encrypt=True;TrustServerCertificate=True",
+    //    "EdFi_Ods": "Data Source=localhost,1434;Initial Catalog=EdFi_Ods;Integrated Security=False;User Id=sa;Password=P@55w0rd;Encrypt=True;TrustServerCertificate=True",
+    //    "EdFi_Master": "Data Source=localhost,1434;Initial Catalog=master;Integrated Security=False;User Id=sa;Password=P@55w0rd;Encrypt=True;TrustServerCertificate=True"
+    //},
     "SwaggerSettings": {
         "EnableSwagger": true,
         "DefaultTenant": "tenant1"

--- a/Docker/Settings/V2/DB-Ods/mssqlPoC/Dockerfile
+++ b/Docker/Settings/V2/DB-Ods/mssqlPoC/Dockerfile
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63
+
+USER root
+
+RUN ACCEPT_EULA=Y apt-get update -y && \
+    ACCEPT_EULA=Y apt-get upgrade -y && \
+    ACCEPT_EULA=Y apt-get -y install --no-install-recommends dos2unix=7.4.2-2 && \
+    rm -rf /var/lib/apt/lists/* && \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    # These steps are needed in order to mount the database to a host volume
+    mkdir -p /var/opt/mssql/data /var/opt/mssql/log && \
+    chown -R mssql: /var/opt/mssql/data /var/opt/mssql/log
+
+LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
+
+ENV MSSQL_PID=Express
+
+WORKDIR /app
+
+COPY --chmod=500 ./init.sh .
+
+RUN dos2unix ./init.sh && \
+    chown mssql ./init.sh && \
+    apt-get --purge autoremove dos2unix -y
+
+EXPOSE 1433
+USER mssql
+ENTRYPOINT ["/app/init.sh"]

--- a/Docker/Settings/V2/DB-Ods/mssqlPoC/init.sh
+++ b/Docker/Settings/V2/DB-Ods/mssqlPoC/init.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+set -e
+set +x
+
+# Export default values
+export MSSQL_SA_PASSWORD=$SQLSERVER_PASSWORD
+export ACCEPT_EULA=Y
+
+/opt/mssql/bin/sqlservr

--- a/Docker/Settings/V2/DB-Ods/pgsqlPoC/Dockerfile
+++ b/Docker/Settings/V2/DB-Ods/pgsqlPoC/Dockerfile
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+FROM postgres:16-alpine
+
+LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
+
+WORKDIR /app
+
+COPY --chmod=500 ./init.sh .
+
+# Normalize line endings in case the file was edited on Windows
+RUN sed -i 's/\r$//' ./init.sh
+
+EXPOSE 5432
+ENTRYPOINT ["/app/init.sh"]

--- a/Docker/Settings/V2/DB-Ods/pgsqlPoC/init.sh
+++ b/Docker/Settings/V2/DB-Ods/pgsqlPoC/init.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+set -e
+
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+PGDATA="${PGDATA:-/var/lib/postgresql/data}"
+MINIMAL_SQL_PATH="${MINIMAL_SQL_PATH:-}"
+POPULATED_SQL_PATH="${POPULATED_SQL_PATH:-}"
+
+if [ ! -s "$PGDATA/PG_VERSION" ]; then
+    # Validate SQL files are provided and accessible before doing any work
+    if [ -z "$MINIMAL_SQL_PATH" ]; then
+        echo "ERROR: MINIMAL_SQL_PATH environment variable is not set."
+        echo "Mount a directory containing your SQL backup files and set MINIMAL_SQL_PATH to the file path inside the container."
+        exit 1
+    fi
+    if [ ! -f "$MINIMAL_SQL_PATH" ]; then
+        echo "ERROR: Minimal SQL file not found at '$MINIMAL_SQL_PATH'."
+        echo "Ensure the file is mounted into the container at the path specified by MINIMAL_SQL_PATH."
+        exit 1
+    fi
+    if [ -z "$POPULATED_SQL_PATH" ]; then
+        echo "ERROR: POPULATED_SQL_PATH environment variable is not set."
+        echo "Mount a directory containing your SQL backup files and set POPULATED_SQL_PATH to the file path inside the container."
+        exit 1
+    fi
+    if [ ! -f "$POPULATED_SQL_PATH" ]; then
+        echo "ERROR: Populated SQL file not found at '$POPULATED_SQL_PATH'."
+        echo "Ensure the file is mounted into the container at the path specified by POPULATED_SQL_PATH."
+        exit 1
+    fi
+
+    echo "Initializing PostgreSQL data directory..."
+    su-exec postgres initdb \
+        --username="$POSTGRES_USER" \
+        --auth-local=trust \
+        --auth-host=md5 \
+        -D "$PGDATA"
+
+    # Allow connections from any host (e.g. Docker bridge, host machine)
+    echo "host all all 0.0.0.0/0 md5" >> "$PGDATA/pg_hba.conf"
+
+    echo "Starting PostgreSQL for initial setup..."
+    su-exec postgres postgres -D "$PGDATA" -p "$POSTGRES_PORT" -c listen_addresses='*' &
+    BG_PID=$!
+
+    retries=0
+    until su-exec postgres pg_isready -U "$POSTGRES_USER" -p "$POSTGRES_PORT" -h localhost; do
+        retries=$((retries + 1))
+        if [ "$retries" -ge 30 ]; then
+            echo "ERROR: PostgreSQL did not become ready within 60 seconds."
+            exit 1
+        fi
+        echo "Waiting for PostgreSQL to be ready... ($retries/30)"
+        sleep 2
+    done
+
+    echo "Setting user password..."
+    su-exec postgres psql -p "$POSTGRES_PORT" -U "$POSTGRES_USER" \
+        -c "ALTER USER \"${POSTGRES_USER}\" WITH PASSWORD '${POSTGRES_PASSWORD}';"
+
+    echo "Creating and restoring Ods_Minimal_Template from $MINIMAL_SQL_PATH..."
+    su-exec postgres psql -p "$POSTGRES_PORT" -U "$POSTGRES_USER" \
+        -c "CREATE DATABASE \"Ods_Minimal_Template\";"
+    PGPASSWORD="$POSTGRES_PASSWORD" su-exec postgres psql \
+        --host=localhost \
+        --port="$POSTGRES_PORT" \
+        --username="$POSTGRES_USER" \
+        --dbname="Ods_Minimal_Template" \
+        -f "$MINIMAL_SQL_PATH"
+    su-exec postgres psql -p "$POSTGRES_PORT" -U "$POSTGRES_USER" \
+        -c "UPDATE pg_database SET datistemplate = true WHERE datname = 'Ods_Minimal_Template';"
+
+    echo "Creating and restoring Ods_Populated_Template from $POPULATED_SQL_PATH..."
+    su-exec postgres psql -p "$POSTGRES_PORT" -U "$POSTGRES_USER" \
+        -c "CREATE DATABASE \"Ods_Populated_Template\";"
+    PGPASSWORD="$POSTGRES_PASSWORD" su-exec postgres psql \
+        --host=localhost \
+        --port="$POSTGRES_PORT" \
+        --username="$POSTGRES_USER" \
+        --dbname="Ods_Populated_Template" \
+        -f "$POPULATED_SQL_PATH"
+    su-exec postgres psql -p "$POSTGRES_PORT" -U "$POSTGRES_USER" \
+        -c "UPDATE pg_database SET datistemplate = true WHERE datname = 'Ods_Populated_Template';"
+
+    echo "Stopping setup instance..."
+    su-exec postgres pg_ctl stop -D "$PGDATA" -m fast
+    wait $BG_PID 2>/dev/null || true
+    echo "Initial setup complete."
+fi
+
+echo "Starting PostgreSQL in foreground..."
+exec su-exec postgres postgres -D "$PGDATA" -p "$POSTGRES_PORT" -c listen_addresses='*'
+

--- a/Docker/V2/Compose/mssql/SingleTenant/compose-build-dev.yml
+++ b/Docker/V2/Compose/mssql/SingleTenant/compose-build-dev.yml
@@ -100,7 +100,7 @@ services:
       SQLSERVER_USER: ${SQLSERVER_USER:-edfi}
       SQLSERVER_PASSWORD: "${SQLSERVER_PASSWORD:-P@55w0rd}"
     ports:
-      - 1433:1433
+      - 1435:1433
     healthcheck:
       test: ["CMD", "/usr/local/bin/healthcheck.sh"]
       interval: 10s

--- a/Docker/V2/Compose/mssql/SingleTenant/compose-build-ods.yml
+++ b/Docker/V2/Compose/mssql/SingleTenant/compose-build-ods.yml
@@ -6,25 +6,26 @@
 services:
   db-ods:
     build:
-      context: ../../../../Settings/shared/DB-Ods/mssql/
+      context: ../../../../Settings/V2/DB-Ods/mssqlPoC/
       dockerfile: Dockerfile
-      args:
-        ODS_VERSION: ${MSSQL_ODS_MINIMAL_VERSION:-7.3.478}
-        TPDM_VERSION: ${MSSQL_TPDM_MINIMAL_VERSION:-7.3.326}
-        STANDARD_VERSION: ${STANDARD_VERSION:-5.2.0}
-        EXTENSION_VERSION: ${EXTENSION_VERSION:-1.1.0}
     environment:
+      SA_PASSWORD: "${SA_PASSWORD:-P@55w0rd}"
       ACCEPT_EULA: "Y"
       SQLSERVER_USER: ${SQLSERVER_USER:-edfi}
       SQLSERVER_PASSWORD: ${SQLSERVER_PASSWORD:-P@55w0rd}
       TPDM_ENABLED: ${TPDM_ENABLED:-true}
       MSSQL_PID: ${MSSQL_PID:-Express}
+      MINIMAL_BAK_PATH: "${MINIMAL_BAK_PATH:-/sql-backups/EdFi.Ods.Minimal.Template.bak}"
+      POPULATED_BAK_PATH: "${POPULATED_BAK_PATH:-/sql-backups/EdFi.Ods.Populated.Template.bak}"
     volumes:
+      - ${SQL_BACKUPS_FOLDER:-C:/mssqlBac/}:/var/opt/mssql/data/sql-backups/:ro
       - vol-db-ods:/var/opt/mssql/data
       - vol-db-ods:/var/opt/mssql/log
     restart: always
     container_name: ed-fi-db-ods
     hostname: ed-fi-db-ods
+    ports:
+      - 1434:1433
     healthcheck:
       test: /opt/mssql-tools18/bin/sqlcmd -U ${SQLSERVER_USER:-edfi} -P "${SQLSERVER_PASSWORD:-P@55w0rd}" -C -Q "SELECT 1"
       start_period: "60s"
@@ -47,7 +48,7 @@ services:
       SQLSERVER_USER: ${SQLSERVER_USER:-edfi}
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
     volumes:
-      - ${LOGS_FOLDER}:/app/logs
+      - ${LOGS_FOLDER:-./logs}:/app/logs
     depends_on:
       - db-ods
       - db-admin

--- a/Docker/V2/Compose/mssql/env.example
+++ b/Docker/V2/Compose/mssql/env.example
@@ -56,3 +56,15 @@ KEYCLOAK_ADMIN_CONSOLE_REALM=edfi-admin-console
 TAG=7.3
 API_HEALTHCHECK_TEST="curl -f http://localhost/health"
 ODS_CONNECTION_STRING_ENCRYPTION_KEY=<Create a new string as symmetric encryption key>
+
+
+
+SQL_BACKUPS_FOLDER=C:/mssqlBac/
+
+# Instance Management database templates. - pgsql
+MINIMAL_SQL_PATH=/var/opt/pgsql/data/sql-backups/EdFi.Ods.Minimal.Template.sql
+POPULATED_SQL_PATH=/var/opt/pgsql/data/sql-backups/EdFi.Ods.Populated.Template.sql
+
+# Instance Management database templates. - mssqp
+MINIMAL_BAK_PATH=C:/mssqlBac/EdFi.Ods.Minimal.Template.bak
+POPULATED_BAK_PATH=C:/mssqlBac/EdFi.Ods.Populated.Template.bak

--- a/Docker/V2/Compose/pgsql/SingleTenant/compose-build-ods.yml
+++ b/Docker/V2/Compose/pgsql/SingleTenant/compose-build-ods.yml
@@ -5,13 +5,21 @@
 
 services:
   db-ods:
-    image: edfialliance/ods-api-db-ods-minimal:${TAG}
+    build:
+      context: ../../../../Settings/V2/DB-Ods/pgsqlPoC/
+      dockerfile: Dockerfile
     environment:
       POSTGRES_USER: "${POSTGRES_USER}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
+      MINIMAL_SQL_PATH: "${MINIMAL_SQL_PATH:-/var/opt/pgsql/data/sql-backups/EdFi.Ods.Minimal.Template.sql}"
+      POPULATED_SQL_PATH: "${POPULATED_SQL_PATH:-/var/opt/pgsql/data/sql-backups/EdFi.Ods.Populated.Template.sql}"
     volumes:
+      - ${SQL_BACKUPS_FOLDER:-C:/pgsqlBak/}:/var/opt/pgsql/data/sql-backups/:ro
       - vol-db-ods:/var/lib/postgresql/data
+    ports:
+      - 5401:5432
     restart: always
     container_name: ed-fi-db-ods
     healthcheck:

--- a/Docker/V2/Compose/pgsql/env.example
+++ b/Docker/V2/Compose/pgsql/env.example
@@ -45,3 +45,15 @@ ADMIN_API_HEALTHCHECK_TEST="wget -nv -t1 --spider http://${ADMIN_API_VIRTUAL_NAM
 TAG=7.3
 API_HEALTHCHECK_TEST="curl -f http://localhost/health"
 ODS_CONNECTION_STRING_ENCRYPTION_KEY=<Create a new string as symmetric encryption key>
+
+
+
+SQL_BACKUPS_FOLDER=C:/pgsqlBak/
+
+# Instance Management database templates. - pgsql
+MINIMAL_SQL_PATH=/var/opt/pgsql/data/sql-backups/EdFi.Ods.Minimal.Template.sql
+POPULATED_SQL_PATH=/var/opt/pgsql/data/sql-backups/EdFi.Ods.Populated.Template.sql
+
+# Instance Management database templates. - mssqp
+MINIMAL_BAK_PATH=C:/mssqlBac/EdFi.Ods.Minimal.Template.bak
+POPULATED_BAK_PATH=C:/mssqlBac/EdFi.Ods.Populated.Template.bak

--- a/docs/http/dbinstances.http
+++ b/docs/http/dbinstances.http
@@ -3,6 +3,12 @@
 @adminapi_secret=adminapi_SECRET_2025_rftyguhijkotgyhuijok
 @tenant=tenant2
 
+### Register a new client
+POST {{adminapi_url}}/connect/register
+Content-Type: application/x-www-form-urlencoded
+
+ClientId={{adminapi_client}}&ClientSecret={{adminapi_secret}}&DisplayName=Admin+API+{{adminapi_client}}
+
 ### Get a token
 # @name tokenRequest
 POST {{adminapi_url}}/connect/token
@@ -55,6 +61,13 @@ Tenant: {{tenant}}
 
 ### Get all DB instances
 GET {{adminapi_url}}/v2/dbinstances
+Content-Type: application/json
+Authorization: bearer {{token}}
+Tenant: {{tenant}}
+
+
+### Get all ODS instances
+GET {{adminapi_url}}/v2/odsinstances
 Content-Type: application/json
 Authorization: bearer {{token}}
 Tenant: {{tenant}}


### PR DESCRIPTION
This PoC contains changes related to how we are going to setup minimal and populated templates on Docker configuration.
For both engines, mssql and pgsql we followed very similar approaches: We download the corresponding Azure artefacts and then extract them:
1. Then, for mssql we just extract them because based on the approached followed, what the user configures on the AppSettings is a path to a set of bak files, in the code these files will be restored.
2. But for pgsql the approach is different, we generate a copy from a template database, which means that once the Azure artefact is extracted, we also restore it.

Since this is a PoC I changed just the single tenant environments for V2. Multitenant environments and V3 are still pending and will be covered on the implementatio ticket.

In order to be able to test this on my environment I setup the databases in Docker, and then I ran the Admin Api from the host machine, in order to be able to debug the code step by step and see how the new data stores (Ods instances) are properly created. I also used the dbinstances.http file.

In relation to supporting multiple data standards, we will talk about that in the review meeting on Wednesday. If necessary we'll create another ticket for the implementation. Admin Api doesn't support multiple data standards at the moment.

UPDATE:
1. Based on comments I changed the approach. Instead of downloading the template databases from Azure artefacts, the user will be responsible for providing those files from the host.
2. Based on conversation with Stephen, we do not need to support multiple data standards. 