### PR TITLE
[ADMINAPI-1440/1441/1442] Standardize V3 claim set payload to flat structure

### DIFF
--- a/Application/EdFi.Ods.AdminApi.V3.DBTests/ClaimSetEditorTests/GetResourcesByClaimSetIdQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApi.V3.DBTests/ClaimSetEditorTests/GetResourcesByClaimSetIdQueryTests.cs
@@ -33,6 +33,7 @@ public class GetResourcesByClaimSetIdQueryTests : SecurityDataTestBase
             results.Length.ShouldBe(testResourceClaimsForId.Length);
             results.Select(x => x.Name).ShouldBe(testResourceClaimsForId.Select(x => x.ResourceName), true);
             results.Select(x => x.Id).ShouldBe(testResourceClaimsForId.Select(x => x.ResourceClaimId), true);
+            results.Select(x => x.ClaimName).ShouldBe(testResourceClaimsForId.Select(x => x.ClaimName), true);
             results.All(x => x.Actions.All(x => x.Name.Equals("Create") && x.Enabled)).ShouldBe(true);
         }
     }
@@ -86,6 +87,7 @@ public class GetResourcesByClaimSetIdQueryTests : SecurityDataTestBase
                 var parentResult = results.First(x => x.Id == testParentResourceClaim.ResourceClaimId);
                 parentResult.Children.Select(x => x.Name).ShouldBe(testChildren.Select(x => x.ResourceName), true);
                 parentResult.Children.Select(x => x.Id).ShouldBe(testChildren.Select(x => x.ResourceClaimId), true);
+                parentResult.Children.Select(x => x.ClaimName).ShouldBe(testChildren.Select(x => x.ClaimName), true);
                 parentResult.Children.All(x => x.Actions.All(x => x.Name.Equals("Create") && x.Enabled)).ShouldBe(true);
             }
 

--- a/Application/EdFi.Ods.AdminApi.V3.UnitTests/Features/ClaimSets/ClaimSetMapperTests.cs
+++ b/Application/EdFi.Ods.AdminApi.V3.UnitTests/Features/ClaimSets/ClaimSetMapperTests.cs
@@ -50,7 +50,7 @@ public class ClaimSetMapperTests
     }
 
     [Test]
-    public void ToResourceClaim_MapsNestedResourceClaimModelValues()
+    public void ToResourceClaim_MapsFlatResourceClaimModelValues()
     {
         var actions = new List<ResourceClaimAction>
         {
@@ -58,22 +58,65 @@ public class ClaimSetMapperTests
         };
         var source = new ClaimSetResourceClaimModel
         {
-            Id = 20,
-            Name = "Parent",
+            Name = "candidatePreparation",
+            ClaimName = "http://ed-fi.org/identity/claims/candidatePreparation",
+            ParentClaimName = "http://ed-fi.org/identity/claims/domains/educationStandards",
             Actions = actions,
-            Children = new List<ClaimSetResourceClaimModel>
-            {
-                new() { Id = 21, Name = "Child" }
-            }
+            DefaultAuthorizationStrategies = new List<ClaimSetResourceClaimActionAuthStrategies>(),
+            AuthorizationStrategyOverrides = new List<ClaimSetResourceClaimActionAuthStrategies>()
         };
 
         var model = ClaimSetMapper.ToResourceClaim(source);
 
-        model.Id.ShouldBe(20);
-        model.Name.ShouldBe("Parent");
+        model.Name.ShouldBe(source.Name);
+        model.ClaimName.ShouldBe(source.ClaimName);
+        model.ParentClaimName.ShouldBe(source.ParentClaimName);
         model.Actions.ShouldBeSameAs(actions);
-        model.Children.Single().Id.ShouldBe(21);
-        model.Children.Single().Name.ShouldBe("Child");
+        model.Children.ShouldBeEmpty();
+    }
+
+    [Test]
+    public void ToResourceClaimList_MapsEachEntryIndependently()
+    {
+        var source = new List<ClaimSetResourceClaimModel>
+        {
+            new() { Name = "educationStandards", ClaimName = "http://ed-fi.org/identity/claims/domains/educationStandards", ParentClaimName = null },
+            new() { Name = "candidatePreparation", ClaimName = "http://ed-fi.org/identity/claims/candidatePreparation", ParentClaimName = "http://ed-fi.org/identity/claims/domains/educationStandards" }
+        };
+
+        var result = ClaimSetMapper.ToResourceClaimList(source);
+
+        result.Count.ShouldBe(2);
+        result[0].Children.ShouldBeEmpty();
+        result[1].Children.ShouldBeEmpty();
+        result[1].ParentClaimName.ShouldBe(source[1].ParentClaimName);
+    }
+
+    [Test]
+    public void ToClaimSetResourceClaimModelList_FlattensNestedTreeWithParentClaimName()
+    {
+        var child = new ResourceClaim
+        {
+            Name = "candidatePreparation",
+            ClaimName = "http://ed-fi.org/identity/claims/candidatePreparation",
+            Actions = new List<ResourceClaimAction>(),
+            Children = new List<ResourceClaim>()
+        };
+        var parent = new ResourceClaim
+        {
+            Name = "educationStandards",
+            ClaimName = "http://ed-fi.org/identity/claims/domains/educationStandards",
+            Actions = new List<ResourceClaimAction>(),
+            Children = new List<ResourceClaim> { child }
+        };
+
+        var result = ClaimSetMapper.ToClaimSetResourceClaimModelList(new List<ResourceClaim> { parent });
+
+        result.Count.ShouldBe(2);
+        result[0].Name.ShouldBe("educationStandards");
+        result[0].ParentClaimName.ShouldBeNull();
+        result[1].Name.ShouldBe("candidatePreparation");
+        result[1].ParentClaimName.ShouldBe("http://ed-fi.org/identity/claims/domains/educationStandards");
     }
 
     [Test]

--- a/Application/EdFi.Ods.AdminApi.V3.UnitTests/Features/ClaimSets/ExportClaimSetTests.cs
+++ b/Application/EdFi.Ods.AdminApi.V3.UnitTests/Features/ClaimSets/ExportClaimSetTests.cs
@@ -18,4 +18,34 @@ namespace EdFi.Ods.AdminApi.V3.UnitTests.Features.ClaimSets;
         var result = await ExportClaimSet.GetClaimSet(fakeGetById, fakeGetResources, fakeGetApps, 1);
         result.ShouldNotBeNull();
     }
+
+    [Test]
+    public async Task GetClaimSet_ReturnsIdenticalPayloadShape_AsReadClaimSetsGetClaimSet()
+    {
+        var fakeGetById = A.Fake<IGetClaimSetByIdQuery>();
+        A.CallTo(() => fakeGetById.Execute(1)).Returns(new ClaimSet { Id = 1, Name = "CS1", IsEditable = true });
+        var fakeGetResources = A.Fake<IGetResourcesByClaimSetIdQuery>();
+        A.CallTo(() => fakeGetResources.AllResources(1)).Returns(new List<ResourceClaim>
+        {
+            new()
+            {
+                Name = "candidatePreparation",
+                ClaimName = "http://ed-fi.org/identity/claims/candidatePreparation",
+                Actions = new List<ResourceClaimAction> { new() { Name = "Read", Enabled = true } }
+            }
+        });
+        var fakeGetApps = A.Fake<IGetApplicationsByClaimSetIdQuery>();
+        A.CallTo(() => fakeGetApps.Execute(1)).Returns(new List<Application>());
+
+        var exportResult = await ExportClaimSet.GetClaimSet(fakeGetById, fakeGetResources, fakeGetApps, 1);
+        var readResult = await ReadClaimSets.GetClaimSet(fakeGetById, fakeGetResources, fakeGetApps, 1);
+
+        var exportValue = ((Microsoft.AspNetCore.Http.HttpResults.Ok<ClaimSetDetailsModel>)exportResult).Value;
+        var readValue = ((Microsoft.AspNetCore.Http.HttpResults.Ok<ClaimSetDetailsModel>)readResult).Value;
+
+        var exportJson = System.Text.Json.JsonSerializer.Serialize(exportValue);
+        var readJson = System.Text.Json.JsonSerializer.Serialize(readValue);
+
+        exportJson.ShouldBe(readJson);
+    }
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Export.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Export.bru
@@ -21,7 +21,7 @@ script:post-response {
   test("ClaimSets Export: Response result matches claimset", function () {
       const claimSetId = bru.getVar("CreatedClaimSetId");
       expect(result.id).to.equal(parseInt(claimSetId));
-      expect(result.name).to.equal(`TestClaimSet-${bru.getVar("ClaimSetGUID")}`);
+      expect(result.claimSetName).to.equal(`TestClaimSet-${bru.getVar("ClaimSetGUID")}`);
       expect(result._isSystemReserved).to.equal(false);
       expect(result._applications).to.be.empty;
   });
@@ -40,6 +40,12 @@ script:post-response {
               "name": {
                 "type": "string"
               },
+              "claimName": {
+                "type": ["string", "null"]
+              },
+              "parentClaimName": {
+                "type": ["string", "null"]
+              },
                "actions": {
                "type": "array",
                "items": [
@@ -52,18 +58,15 @@ script:post-response {
                       "enabled": {
                         "type": "boolean"
                       }
-                  } 
+                  }
                   } ]
               },
-              "_defaultAuthorizationStrategiesForCRUD": {
+              "_defaultAuthorizationStrategies": {
                 "type": "array",
                 "items": [
                   {
                     "type": "object",
                     "properties": {
-                      "actionId": {
-                        "type": "integer"
-                      },
                       "actionName": {
                         "type": "string"
                       },
@@ -73,33 +76,23 @@ script:post-response {
                             {
                               "type": "object",
                               "properties": {
-                                  "authStrategyId": {
-                                  "type": "integer"
-                                  },
                                   "authStrategyName": {
                                   "type": "string"
-                                  },
-                                  "isInheritedFromParent": {
-                                  "type": "boolean"
-                                  }                      
-
+                                  }
                               }
                             }
                         ]
-                      }                    
+                      }
                     }
                   }
                 ]
               },
-              "authorizationStrategyOverridesForCRUD": {
+              "authorizationStrategyOverrides": {
                 "type": "array",
                  "items": [
                   {
                     "type": "object",
                     "properties": {
-                      "actionId": {
-                        "type": "integer"
-                      },
                       "actionName": {
                         "type": "string"
                       },
@@ -109,34 +102,23 @@ script:post-response {
                             {
                               "type": "object",
                               "properties": {
-                                  "authStrategyId": {
-                                  "type": "integer"
-                                  },
                                   "authStrategyName": {
                                   "type": "string"
-                                  },
-                                  "isInheritedFromParent": {
-                                  "type": "boolean"
                                   }
                               }
                             }
                         ]
-                      }                    
+                      }
                     }
                   }
                 ]
-              },
-              "children": {
-                "type": "array",
-                "items": {}
               }
             },
             "required": [
               "name",
               "actions",
-              "_defaultAuthorizationStrategiesForCRUD",
-              "authorizationStrategyOverridesForCRUD",
-              "children"
+              "_defaultAuthorizationStrategies",
+              "authorizationStrategyOverrides"
             ]
           }
         ]
@@ -144,7 +126,7 @@ script:post-response {
       "id": {
         "type": "integer"
       },
-      "name": {
+      "claimSetName": {
         "type": "string"
       },
       "_isSystemReserved": {
@@ -158,7 +140,7 @@ script:post-response {
     "required": [
       "resourceClaims",
       "id",
-      "name",
+      "claimSetName",
       "_isSystemReserved",
       "_applications"
     ]

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Without Limit.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Without Limit.bru
@@ -37,7 +37,7 @@ script:post-response {
           "id": {
             "type": "integer"
           },
-          "name": {
+          "claimSetName": {
             "type": "string"
           },
           "_isSystemReserved": {
@@ -50,7 +50,7 @@ script:post-response {
         },
         "required": [
           "id",
-          "name",
+          "claimSetName",
           "_isSystemReserved",
           "_applications"
         ]

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Without Offset and Limit.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Without Offset and Limit.bru
@@ -33,7 +33,7 @@ script:post-response {
           "id": {
             "type": "integer"
           },
-          "name": {
+          "claimSetName": {
             "type": "string"
           },
           "_isSystemReserved": {
@@ -46,7 +46,7 @@ script:post-response {
         },
         "required": [
           "id",
-          "name",
+          "claimSetName",
           "_isSystemReserved",
           "_applications"
         ]

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Without Offset.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Without Offset.bru
@@ -37,7 +37,7 @@ script:post-response {
           "id": {
             "type": "integer"
           },
-          "name": {
+          "claimSetName": {
             "type": "string"
           },
           "_isSystemReserved": {
@@ -50,7 +50,7 @@ script:post-response {
         },
         "required": [
           "id",
-          "name",
+          "claimSetName",
           "_isSystemReserved",
           "_applications"
         ]

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets by ID after adding Action.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets by ID after adding Action.bru
@@ -22,13 +22,13 @@ script:post-response {
       const claimSetId = bru.getVar("CreatedClaimSetId");
       
       expect(result.id).to.equal(parseInt(claimSetId));
-      expect(result.name).to.equal(`TestClaimSet-${bru.getVar("ClaimSetGUID")}`);
+      expect(result.claimSetName).to.equal(`TestClaimSet-${bru.getVar("ClaimSetGUID")}`);
       expect(result._isSystemReserved).to.equal(false);
       expect(result._applications).to.be.empty;
       expect(result.resourceClaims).to.not.be.empty;
       const educationOrganizationsResourceClaim = result.resourceClaims.find(r => r.name === "educationOrganizations")
       expect(educationOrganizationsResourceClaim).to.be.an("object", "The educationOrganizations resource claim was not found.")
-      const actionCreate = educationOrganizationsResourceClaim._defaultAuthorizationStrategiesForCRUD.find(r => r.actionName === "Create")
+      const actionCreate = educationOrganizationsResourceClaim._defaultAuthorizationStrategies.find(r => r.actionName === "Create")
       expect(actionCreate).to.be.an("object", "The Create resource claim action was not found.")
   });
   
@@ -46,6 +46,12 @@ script:post-response {
               "name": {
                 "type": "string"
               },
+              "claimName": {
+                "type": ["string", "null"]
+              },
+              "parentClaimName": {
+                "type": ["string", "null"]
+              },
               "actions": {
                "type": "array",
                "items": [
@@ -58,18 +64,15 @@ script:post-response {
                       "enabled": {
                         "type": "boolean"
                       }
-                  } 
+                  }
                   } ]
               },
-              "_defaultAuthorizationStrategiesForCRUD": {
+              "_defaultAuthorizationStrategies": {
                 "type": "array",
                 "items": [
                   {
                     "type": "object",
                     "properties": {
-                      "actionId": {
-                        "type": "integer"
-                      },
                       "actionName": {
                         "type": "string"
                       },
@@ -79,33 +82,23 @@ script:post-response {
                             {
                               "type": "object",
                               "properties": {
-                                  "authStrategyId": {
-                                  "type": "integer"
-                                  },
                                   "authStrategyName": {
                                   "type": "string"
-                                  },
-                                  "isInheritedFromParent": {
-                                  "type": "boolean"
-                                  }                      
-  
+                                  }
                               }
                             }
                         ]
-                      }                    
+                      }
                     }
                   }
                 ]
               },
-              "authorizationStrategyOverridesForCRUD": {
+              "authorizationStrategyOverrides": {
                 "type": "array",
                  "items": [
                   {
                     "type": "object",
                     "properties": {
-                      "actionId": {
-                        "type": "integer"
-                      },
                       "actionName": {
                         "type": "string"
                       },
@@ -115,34 +108,23 @@ script:post-response {
                             {
                               "type": "object",
                               "properties": {
-                                  "authStrategyId": {
-                                  "type": "integer"
-                                  },
                                   "authStrategyName": {
                                   "type": "string"
-                                  },
-                                  "isInheritedFromParent": {
-                                  "type": "boolean"
                                   }
                               }
                             }
                         ]
-                      }                    
+                      }
                     }
                   }
                 ]
-              },
-              "children": {
-                "type": "array",
-                "items": {}
               }
             },
             "required": [
               "name",
               "actions",
-              "_defaultAuthorizationStrategiesForCRUD",
-              "authorizationStrategyOverridesForCRUD",
-              "children"
+              "_defaultAuthorizationStrategies",
+              "authorizationStrategyOverrides"
             ]
           }
         ]
@@ -150,7 +132,7 @@ script:post-response {
       "id": {
         "type": "integer"
       },
-      "name": {
+      "claimSetName": {
         "type": "string"
       },
       "_isSystemReserved": {
@@ -164,7 +146,7 @@ script:post-response {
     "required": [
       "resourceClaims",
       "id",
-      "name",
+      "claimSetName",
       "_isSystemReserved",
       "_applications"
     ]

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets by ID after overriding Authorization Strategy.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets by ID after overriding Authorization Strategy.bru
@@ -22,15 +22,15 @@ script:post-response {
       const claimSetId = bru.getVar("CreatedClaimSetId");
       
       expect(result.id).to.equal(parseInt(claimSetId));
-      expect(result.name).to.equal(`TestClaimSet-${bru.getVar("ClaimSetGUID")}`);
+      expect(result.claimSetName).to.equal(`TestClaimSet-${bru.getVar("ClaimSetGUID")}`);
       expect(result._isSystemReserved).to.equal(false);
       expect(result._applications).to.be.empty;
       expect(result.resourceClaims).to.not.be.empty;
-  
+
       const educationOrganizationsResourceClaim = result.resourceClaims.find(r => r.name === "educationOrganizations")
       expect(educationOrganizationsResourceClaim).to.be.an("object", "The educationOrganizations resource claim was not found.")
-      expect(educationOrganizationsResourceClaim.authorizationStrategyOverridesForCRUD).to.not.be.empty;
-      const overrideAuthCreate = educationOrganizationsResourceClaim.authorizationStrategyOverridesForCRUD.find(r => r.actionName === "Create")
+      expect(educationOrganizationsResourceClaim.authorizationStrategyOverrides).to.not.be.empty;
+      const overrideAuthCreate = educationOrganizationsResourceClaim.authorizationStrategyOverrides.find(r => r.actionName === "Create")
       expect(overrideAuthCreate).to.be.an("object", "The Create authorization override was not found.")
       //validates that default wasn't added
       expect(overrideAuthCreate.authorizationStrategies.length).to.equal(1);
@@ -52,6 +52,12 @@ script:post-response {
               "name": {
                 "type": "string"
               },
+              "claimName": {
+                "type": ["string", "null"]
+              },
+              "parentClaimName": {
+                "type": ["string", "null"]
+              },
                "actions": {
                "type": "array",
                "items": [
@@ -64,18 +70,15 @@ script:post-response {
                       "enabled": {
                         "type": "boolean"
                       }
-                  } 
+                  }
                   } ]
               },
-              "_defaultAuthorizationStrategiesForCRUD": {
+              "_defaultAuthorizationStrategies": {
                 "type": "array",
                 "items": [
                   {
                     "type": "object",
                     "properties": {
-                      "actionId": {
-                        "type": "integer"
-                      },
                       "actionName": {
                         "type": "string"
                       },
@@ -85,33 +88,23 @@ script:post-response {
                             {
                               "type": "object",
                               "properties": {
-                                  "authStrategyId": {
-                                  "type": "integer"
-                                  },
                                   "authStrategyName": {
                                   "type": "string"
-                                  },
-                                  "isInheritedFromParent": {
-                                  "type": "boolean"
-                                  }                      
-  
+                                  }
                               }
                             }
                         ]
-                      }                    
+                      }
                     }
                   }
                 ]
               },
-              "authorizationStrategyOverridesForCRUD": {
+              "authorizationStrategyOverrides": {
                 "type": "array",
                  "items": [
                   {
                     "type": "object",
                     "properties": {
-                      "actionId": {
-                        "type": "integer"
-                      },
                       "actionName": {
                         "type": "string"
                       },
@@ -121,34 +114,23 @@ script:post-response {
                             {
                               "type": "object",
                               "properties": {
-                                  "authStrategyId": {
-                                  "type": "integer"
-                                  },
                                   "authStrategyName": {
                                   "type": "string"
-                                  },
-                                  "isInheritedFromParent": {
-                                  "type": "boolean"
                                   }
                               }
                             }
                         ]
-                      }                    
+                      }
                     }
                   }
                 ]
-              },
-              "children": {
-                "type": "array",
-                "items": {}
               }
             },
             "required": [
               "name",
               "actions",
-              "_defaultAuthorizationStrategiesForCRUD",
-              "authorizationStrategyOverridesForCRUD",
-              "children"
+              "_defaultAuthorizationStrategies",
+              "authorizationStrategyOverrides"
             ]
           }
         ]
@@ -156,7 +138,7 @@ script:post-response {
       "id": {
         "type": "integer"
       },
-      "name": {
+      "claimSetName": {
         "type": "string"
       },
       "_isSystemReserved": {
@@ -170,7 +152,7 @@ script:post-response {
     "required": [
       "resourceClaims",
       "id",
-      "name",
+      "claimSetName",
       "_isSystemReserved",
       "_applications"
     ]

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets by ID.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets by ID.bru
@@ -21,7 +21,7 @@ script:post-response {
   test("GET ClaimSetsId: Response result matches claimset", function () {
       const claimSetId = bru.getVar("CreatedClaimSetId");
       expect(result.id).to.equal(parseInt(claimSetId));
-      expect(result.name).to.equal(`TestClaimSet-${bru.getVar("ClaimSetGUID")}`);
+      expect(result.claimSetName).to.equal(`TestClaimSet-${bru.getVar("ClaimSetGUID")}`);
       expect(result._isSystemReserved).to.equal(false);
       expect(result._applications).to.be.empty;
   });
@@ -40,6 +40,12 @@ script:post-response {
               "name": {
                 "type": "string"
               },
+              "claimName": {
+                "type": ["string", "null"]
+              },
+              "parentClaimName": {
+                "type": ["string", "null"]
+              },
                "actions": {
                "type": "array",
                "items": [
@@ -52,18 +58,15 @@ script:post-response {
                       "enabled": {
                         "type": "boolean"
                       }
-                  } 
+                  }
                   } ]
               },
-              "_defaultAuthorizationStrategiesForCRUD": {
+              "_defaultAuthorizationStrategies": {
                 "type": "array",
                 "items": [
                   {
                     "type": "object",
                     "properties": {
-                      "actionId": {
-                        "type": "integer"
-                      },
                       "actionName": {
                         "type": "string"
                       },
@@ -73,33 +76,23 @@ script:post-response {
                             {
                               "type": "object",
                               "properties": {
-                                  "authStrategyId": {
-                                  "type": "integer"
-                                  },
                                   "authStrategyName": {
                                   "type": "string"
-                                  },
-                                  "isInheritedFromParent": {
-                                  "type": "boolean"
-                                  }                      
-  
+                                  }
                               }
                             }
                         ]
-                      }                    
+                      }
                     }
                   }
                 ]
               },
-              "authorizationStrategyOverridesForCRUD": {
+              "authorizationStrategyOverrides": {
                 "type": "array",
                  "items": [
                   {
                     "type": "object",
                     "properties": {
-                      "actionId": {
-                        "type": "integer"
-                      },
                       "actionName": {
                         "type": "string"
                       },
@@ -109,34 +102,23 @@ script:post-response {
                             {
                               "type": "object",
                               "properties": {
-                                  "authStrategyId": {
-                                  "type": "integer"
-                                  },
                                   "authStrategyName": {
                                   "type": "string"
-                                  },
-                                  "isInheritedFromParent": {
-                                  "type": "boolean"
                                   }
                               }
                             }
                         ]
-                      }                    
+                      }
                     }
                   }
                 ]
-              },
-              "children": {
-                "type": "array",
-                "items": {}
               }
             },
             "required": [
               "name",
               "actions",
-              "_defaultAuthorizationStrategiesForCRUD",
-              "authorizationStrategyOverridesForCRUD",
-              "children"
+              "_defaultAuthorizationStrategies",
+              "authorizationStrategyOverrides"
             ]
           }
         ]
@@ -144,7 +126,7 @@ script:post-response {
       "id": {
         "type": "integer"
       },
-      "name": {
+      "claimSetName": {
         "type": "string"
       },
       "_isSystemReserved": {
@@ -158,7 +140,7 @@ script:post-response {
     "required": [
       "resourceClaims",
       "id",
-      "name",
+      "claimSetName",
       "_isSystemReserved",
       "_applications"
     ]

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets.bru
@@ -38,7 +38,7 @@ script:post-response {
           "id": {
             "type": "integer"
           },
-          "name": {
+          "claimSetName": {
             "type": "string"
           },
           "_isSystemReserved": {
@@ -51,7 +51,7 @@ script:post-response {
         },
         "required": [
           "id",
-          "name",
+          "claimSetName",
           "_isSystemReserved",
           "_applications"
         ]

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Api Mode.bru
@@ -33,8 +33,7 @@ body:json {
             "enabled": true
           }
         ],      
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {     
         "name": "academicSubjectDescriptor",
@@ -57,8 +56,7 @@ body:json {
           }  
      
         ],
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {
         "name": "gradeLevelDescriptor",
@@ -81,8 +79,7 @@ body:json {
           }
         ],
        
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {      
         "name": "publicationStatusDescriptor",
@@ -104,8 +101,7 @@ body:json {
             "enabled": true
           }
         ],     
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       }
     ],
     "name": "TestClaimSet-import-{{ImportClaimSetGUID}}"

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Existing ClaimSet Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Existing ClaimSet Name.bru
@@ -33,8 +33,7 @@ body:json {
             "enabled": true
           }
         ],      
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {     
         "name": "academicSubjectDescriptor",
@@ -57,8 +56,7 @@ body:json {
           }  
      
         ],
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {
         "name": "gradeLevelDescriptor",
@@ -81,8 +79,7 @@ body:json {
           }
         ],
        
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {      
         "name": "publicationStatusDescriptor",
@@ -104,8 +101,7 @@ body:json {
             "enabled": true
           }
         ],     
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       }
     ],
     "name": "OtherTestClaimSet-{{OtherClaimSetGUID}}"

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Resource Duplication.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Resource Duplication.bru
@@ -33,8 +33,7 @@ body:json {
             "enabled": true
           }
         ],      
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {     
         "name": "gradeLevelDescriptor",
@@ -57,8 +56,7 @@ body:json {
           }  
      
         ],
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {
         "name": "gradeLevelDescriptor",
@@ -81,8 +79,7 @@ body:json {
           }
         ],
        
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {      
         "name": "publicationStatusDescriptor",
@@ -104,8 +101,7 @@ body:json {
             "enabled": true
           }
         ],     
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       }
     ],
     "name": "WrongRelationship-{{DuplicateClaimSetGUID}}"

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Wrong Parent Child Relationship.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Wrong Parent Child Relationship.bru
@@ -33,33 +33,30 @@ body:json {
             "enabled": true
           }
         ],      
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": [
-             {
-              "name": "academicSubjectDescriptor",
-              "actions": [
-                  {
-                  "name": "Create",
-                  "enabled": true
-                  },
-                  {
-                  "name": "Read",
-                  "enabled": true
-                  },
-                  {
-                  "name": "Update",
-                  "enabled": true
-                  },
-                  {
-                  "name": "Delete",
-                  "enabled": true
-                  }  
-          
-              ],
-              "authorizationStrategyOverridesForCRUD": [],
-              "children": []
-              }
-        ]
+        "authorizationStrategyOverrides": []
+      },
+      {
+        "name": "academicSubjectDescriptor",
+        "parentClaimName": "http://ed-fi.org/identity/claims/domains/educationStandards",
+        "actions": [
+            {
+            "name": "Create",
+            "enabled": true
+            },
+            {
+            "name": "Read",
+            "enabled": true
+            },
+            {
+            "name": "Update",
+            "enabled": true
+            },
+            {
+            "name": "Delete",
+            "enabled": true
+            }
+        ],
+        "authorizationStrategyOverrides": []
       },
       {
         "name": "gradeLevelDescriptor",
@@ -82,8 +79,7 @@ body:json {
           }
         ],
        
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {      
         "name": "publicationStatusDescriptor",
@@ -105,8 +101,7 @@ body:json {
             "enabled": true
           }
         ],     
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       }
     ],
     "name": "WrongRelationship-{{InvalidParentClaimSetGUID}}"

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Wrong resource name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Wrong resource name.bru
@@ -33,8 +33,7 @@ body:json {
             "enabled": true
           }
         ],      
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {     
         "name": "academicSubjectDescriptor",
@@ -57,8 +56,7 @@ body:json {
           }  
      
         ],
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {
         "name": "gradeLevelDescriptor",
@@ -81,8 +79,7 @@ body:json {
           }
         ],
        
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {      
         "name": "publicationStatusDescriptor",
@@ -104,8 +101,7 @@ body:json {
             "enabled": true
           }
         ],     
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       }
     ],
     "name": "WrongResourceName-{{WrongNameClaimSetGUID}}"

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import.bru
@@ -33,8 +33,7 @@ body:json {
             "enabled": true
           }
         ],      
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {     
         "name": "academicSubjectDescriptor",
@@ -57,8 +56,7 @@ body:json {
           }  
      
         ],
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {
         "name": "gradeLevelDescriptor",
@@ -81,8 +79,7 @@ body:json {
           }
         ],
        
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {      
         "name": "publicationStatusDescriptor",
@@ -104,8 +101,7 @@ body:json {
             "enabled": true
           }
         ],     
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       },
       {      
         "name": "candidatePreparation",
@@ -127,8 +123,7 @@ body:json {
             "enabled": true
           }
         ],     
-        "authorizationStrategyOverridesForCRUD": [],
-        "children": []
+        "authorizationStrategyOverrides": []
       }
     ],
     "name": "TestClaimSet-import-{{ImportClaimSetGUID}}"

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets-Copy.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets-Copy.bru
@@ -145,8 +145,8 @@ script:post-response {
       console.log("✅ ClaimSets Returned:", copiedClaimSetResponse.data.id);
       test("POST ClaimSets: Response result claimset has expected name and resource claims", function () {
        expect(copiedClaimSetResponse.data).to.have.property("id");
-       expect(copiedClaimSetResponse.data).to.have.property("name");
-       expect(copiedClaimSetResponse.data.name).contains("CopiedClaimSet-from");
+       expect(copiedClaimSetResponse.data).to.have.property("claimSetName");
+       expect(copiedClaimSetResponse.data.claimSetName).contains("CopiedClaimSet-from");
        expect(copiedClaimSetResponse.data.resourceClaims).to.not.be.empty;
        const resourceclaimexists = copiedClaimSetResponse.data.resourceClaims.some(r => r.name === "educationStandards");
        expect(resourceclaimexists).to.equal(true);

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets.bru
@@ -62,7 +62,7 @@ script:post-response {
     if (claimSetResponse.status === 200 && claimSetResponse.data) {
       console.log("✅ ClaimSets Returned:", claimSetResponse.data.id);
       test("PUT ClaimSets: Response result includes updated claimset", function () {
-          expect(claimSetResponse.data.name).to.equal("UpdatedTestClaimSet");
+          expect(claimSetResponse.data.claimSetName).to.equal("UpdatedTestClaimSet");
           expect(claimSetResponse.data._isSystemReserved).to.equal(false);
           expect(claimSetResponse.data._applications).to.be.empty;
           expect(claimSetResponse.data.resourceClaims).to.not.be.empty;

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/Sorting and Filtering/Get Claimsets filter by Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/Sorting and Filtering/Get Claimsets filter by Name.bru
@@ -28,7 +28,7 @@ script:post-response {
   
   test("GET Claimsets: Response result contains requested claimset", function () {
       const results = res.getBody();
-      expect(results[0].name).to.eql(bru.getEnvVar("FILTERCLAIMSETSNAME"));
+      expect(results[0].claimSetName).to.eql(bru.getEnvVar("FILTERCLAIMSETSNAME"));
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/Sorting and Filtering/Get Claimsets order by Default ASC.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/Sorting and Filtering/Get Claimsets order by Default ASC.bru
@@ -30,7 +30,7 @@ script:post-response {
   
   test("GET Claimsets: Response result is ordered by Name asc", function () {
       const results = res.getBody();
-      var expectedSortedOrder = _.orderBy(results, [claimset => claimset.name],['asc']);
+      var expectedSortedOrder = _.orderBy(results, [claimset => claimset.claimSetName],['asc']);
       expect(results).to.eql(expectedSortedOrder);
   });
   

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/Sorting and Filtering/Get Claimsets order by Default Desc.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/Sorting and Filtering/Get Claimsets order by Default Desc.bru
@@ -30,7 +30,7 @@ script:post-response {
   
   test("GET Claimsets: Response result is ordered by Name asc", function () {
       const results = res.getBody();
-      var expectedSortedOrder = _.orderBy(results, [claimset => claimset.name],['desc']);
+      var expectedSortedOrder = _.orderBy(results, [claimset => claimset.claimSetName],['desc']);
       expect(results).to.eql(expectedSortedOrder);
   });
   

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/Sorting and Filtering/Get Claimsets order by Name ASC.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/Sorting and Filtering/Get Claimsets order by Name ASC.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("GET Claimsets: Response result is ordered by Name asc", function () {
       const results = res.getBody();
-      var expectedSortedOrder = _.orderBy(results, [claimset => claimset.name],['asc']);
+      var expectedSortedOrder = _.orderBy(results, [claimset => claimset.claimSetName],['asc']);
       expect(results).to.eql(expectedSortedOrder);
   });
   

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/Sorting and Filtering/Get Claimsets order by Name Desc.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/Sorting and Filtering/Get Claimsets order by Name Desc.bru
@@ -50,7 +50,7 @@ script:post-response {
           return clone; 
       }
       
-      let expectedSortedOrder = sortByProperty(results, 'name', -1);
+      let expectedSortedOrder = sortByProperty(results, 'claimSetName', -1);
       
       expect(results).to.eql(expectedSortedOrder);
   });

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/User Management Authorization Scopes/GET - ClaimSets - Full Access.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/User Management Authorization Scopes/GET - ClaimSets - Full Access.bru
@@ -49,7 +49,7 @@ script:post-response {
           "id": {
             "type": "integer"
           },
-          "name": {
+          "claimSetName": {
             "type": "string"
           },
           "_isSystemReserved": {
@@ -62,7 +62,7 @@ script:post-response {
         },
         "required": [
           "id",
-          "name",
+          "claimSetName",
           "_isSystemReserved",
           "_applications"
         ]

--- a/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ClaimSetMapper.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ClaimSetMapper.cs
@@ -9,6 +9,16 @@ using SecurityAuthorizationStrategy = EdFi.Security.DataAccess.Models.Authorizat
 
 namespace EdFi.Ods.AdminApi.V3.Features.ClaimSets;
 
+/// <summary>
+/// The only translation seam between the internal, nested ClaimSetEditor resource-claim tree
+/// (<see cref="ResourceClaim"/>, used by GetResourcesByClaimSetIdQuery, AuthStrategyResolver,
+/// AddOrEditResourcesOnClaimSetCommand, and the per-node editing endpoints EditAuthStrategy /
+/// EditResourceClaimActions / DeleteResourceClaim) and the public, flat v3
+/// <see cref="ClaimSetResourceClaimModel"/> shape (claimName/parentClaimName based, per the
+/// Claim Set Export/Import API Design doc). This is "Approach A": the internal pipeline is left
+/// nested/tree-shaped on purpose (it's shared with unrelated editing endpoints), and all
+/// flattening/unflattening happens only here.
+/// </summary>
 public static class ClaimSetMapper
 {
     public static ClaimSetModel ToModel(ClaimSet source)
@@ -52,34 +62,55 @@ public static class ClaimSetMapper
         return source.Select(ToSimpleApplicationModel).ToList();
     }
 
-    public static ClaimSetResourceClaimModel ToClaimSetResourceClaimModel(ResourceClaim source)
-    {
-        return new ClaimSetResourceClaimModel
-        {
-            Id = source.Id,
-            Name = source.Name,
-            Actions = source.Actions,
-            DefaultAuthorizationStrategiesForCRUD = source.DefaultAuthorizationStrategiesForCRUD,
-            AuthorizationStrategyOverridesForCRUD = source.AuthorizationStrategyOverridesForCRUD,
-            Children = ToClaimSetResourceClaimModelList(source.Children)
-        };
-    }
-
+    /// <summary>
+    /// Flattens the internal nested resource-claim tree into the public flat list, recording
+    /// each node's parent's ClaimName as its parentClaimName (null for roots).
+    /// </summary>
     public static List<ClaimSetResourceClaimModel> ToClaimSetResourceClaimModelList(IEnumerable<ResourceClaim> source)
     {
-        return source.Select(ToClaimSetResourceClaimModel).ToList();
+        var flatList = new List<ClaimSetResourceClaimModel>();
+        foreach (var resourceClaim in source)
+        {
+            FlattenResourceClaim(resourceClaim, null, flatList);
+        }
+        return flatList;
     }
 
+    private static void FlattenResourceClaim(ResourceClaim source, string? parentClaimName, List<ClaimSetResourceClaimModel> flatList)
+    {
+        flatList.Add(new ClaimSetResourceClaimModel
+        {
+            Name = source.Name,
+            ClaimName = source.ClaimName,
+            ParentClaimName = parentClaimName,
+            Actions = source.Actions,
+            DefaultAuthorizationStrategies = source.DefaultAuthorizationStrategiesForCRUD,
+            AuthorizationStrategyOverrides = source.AuthorizationStrategyOverridesForCRUD
+        });
+
+        foreach (var child in source.Children)
+        {
+            FlattenResourceClaim(child, source.ClaimName, flatList);
+        }
+    }
+
+    /// <summary>
+    /// Maps one inbound flat DTO entry to an internal ResourceClaim. Children is always left
+    /// empty: AddOrEditResourcesOnClaimSetCommand.Execute already flattens
+    /// (resources.SelectMany(x => x.Children)) and matches purely by Name, so a flat 1:1
+    /// mapping is sufficient and no tree reconstruction is required.
+    /// </summary>
     public static ResourceClaim ToResourceClaim(ClaimSetResourceClaimModel source)
     {
         return new ResourceClaim
         {
-            Id = source.Id,
             Name = source.Name,
+            ClaimName = source.ClaimName,
+            ParentClaimName = source.ParentClaimName,
             Actions = source.Actions,
-            DefaultAuthorizationStrategiesForCRUD = source.DefaultAuthorizationStrategiesForCRUD,
-            AuthorizationStrategyOverridesForCRUD = source.AuthorizationStrategyOverridesForCRUD,
-            Children = ToResourceClaimList(source.Children)
+            DefaultAuthorizationStrategiesForCRUD = source.DefaultAuthorizationStrategies,
+            AuthorizationStrategyOverridesForCRUD = source.AuthorizationStrategyOverrides,
+            Children = new List<ResourceClaim>()
         };
     }
 
@@ -129,5 +160,3 @@ public static class ClaimSetMapper
         return source.Select(item => ToAuthorizationStrategy(item, isInheritedFromParent)).ToList();
     }
 }
-
-

--- a/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ClaimSetModel.cs
@@ -5,7 +5,6 @@
 
 using EdFi.Ods.AdminApi.V3.Features.Applications;
 using EdFi.Ods.AdminApi.V3.Infrastructure.ClaimSetEditor;
-using EdFi.Ods.AdminApi.V3.Infrastructure.Documentation;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Text.Json.Serialization;
 

--- a/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ClaimSetModel.cs
@@ -3,77 +3,73 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using EdFi.Ods.AdminApi.V3.Features.Applications;
+using EdFi.Ods.AdminApi.V3.Features.Applications;
 using EdFi.Ods.AdminApi.V3.Infrastructure.ClaimSetEditor;
-using EdFi.Ods.AdminApi.V3.Infrastructure.Documentation;using Swashbuckle.AspNetCore.Annotations;
-using System.Linq;using System.Text.Json.Serialization;
+using EdFi.Ods.AdminApi.V3.Infrastructure.Documentation;
+using Swashbuckle.AspNetCore.Annotations;
+using System.Text.Json.Serialization;
+
 namespace EdFi.Ods.AdminApi.V3.Features.ClaimSets;
 
 [SwaggerSchema(Title = "ClaimSet")]
 public class ClaimSetModel
 {
     public int Id { get; set; }
-    public string? Name { get; set; }
-    [JsonPropertyName("_isSystemReserved")]
+
+    [JsonPropertyName("claimSetName")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("_isSystemReserved")]
     [SwaggerSchema(ReadOnly = true)]
-    public bool IsSystemReserved { get; set; }
-    [JsonPropertyName("_applications")]
-    [SwaggerSchema(ReadOnly = true)]
+    public bool IsSystemReserved { get; set; }
+
+    [JsonPropertyName("_applications")]
+    [SwaggerSchema(ReadOnly = true)]
     public List<SimpleApplicationModel> Applications { get; set; } = new();
 }
-
+
 [SwaggerSchema(Title = "ClaimSetWithResources")]
 public class ClaimSetDetailsModel : ClaimSetModel
 {
     public List<ClaimSetResourceClaimModel> ResourceClaims { get; set; } = new();
-}
-
+}
 
 [SwaggerSchema(Title = "ClaimSetResourceClaim")]
 public class ClaimSetResourceClaimModel
 {
-    [SwaggerSchema(ReadOnly = true)]
-    public int Id { get; set; }
     public string? Name { get; set; }
+
+    public string? ClaimName { get; set; }
+
+    public string? ParentClaimName { get; set; }
+
     public List<ResourceClaimAction>? Actions { get; set; }
 
-    [JsonPropertyName("_defaultAuthorizationStrategiesForCRUD")]
+    [JsonPropertyName("_defaultAuthorizationStrategies")]
     [SwaggerSchema(ReadOnly = true)]
-    public List<ClaimSetResourceClaimActionAuthStrategies?> DefaultAuthorizationStrategiesForCRUD { get; set; }
+    public List<ClaimSetResourceClaimActionAuthStrategies?> DefaultAuthorizationStrategies { get; set; }
 
-    public List<ClaimSetResourceClaimActionAuthStrategies?> AuthorizationStrategyOverridesForCRUD { get; set; }
-
-    [SwaggerSchema(Description = "Children are collection of ResourceClaim")]
-    public List<ClaimSetResourceClaimModel> Children { get; set; }
+    public List<ClaimSetResourceClaimActionAuthStrategies?> AuthorizationStrategyOverrides { get; set; }
 
     public ClaimSetResourceClaimModel()
     {
-        Children = new List<ClaimSetResourceClaimModel>();
-        DefaultAuthorizationStrategiesForCRUD = new List<ClaimSetResourceClaimActionAuthStrategies?>();
-        AuthorizationStrategyOverridesForCRUD = new List<ClaimSetResourceClaimActionAuthStrategies?>();
+        DefaultAuthorizationStrategies = new List<ClaimSetResourceClaimActionAuthStrategies?>();
+        AuthorizationStrategyOverrides = new List<ClaimSetResourceClaimActionAuthStrategies?>();
         Actions = new List<ResourceClaimAction>();
     }
 }
 
-public class ChildrenClaimSetResource : ClaimSetResourceClaimModel
-{
-    [SwaggerSchema(Description = "Children are collection of ResourceClaim")]
-    public new ClaimSetResourceClaimModel Children { get; set; }
-
-    public ChildrenClaimSetResource()
-    {
-        Children = new ClaimSetResourceClaimModel();
-    }
-}
 [SwaggerSchema(Title = "ResourceClaimModel")]
 public class ResourceClaimModel
 {
     public int Id { get; set; }
-    public string? Name { get; set; }
-    public int? ParentId { get; set; }
-    public string? ParentName { get; set; }
+    public string? Name { get; set; }
+    public int? ParentId { get; set; }
+    public string? ParentName { get; set; }
+
     [SwaggerSchema(Description = "Children are collection of SimpleResourceClaimModel")]
     public List<ResourceClaimModel> Children { get; set; }
+
     public ResourceClaimModel()
     {
         Children = new List<ResourceClaimModel>();
@@ -99,12 +95,11 @@ public class DeleteClaimSetModel : IDeleteClaimSetModel
     public string? Name { get; set; }
 
     public int Id { get; set; }
-}
+}
+
 public interface IResourceClaimOnClaimSetRequest
 {
-    int ClaimSetId { get; }
-    int ResourceClaimId { get; }
-    public List<ResourceClaimAction>? ResourceClaimActions { get; }
-}
-
-
+    int ClaimSetId { get; }
+    int ResourceClaimId { get; }
+    public List<ResourceClaimAction>? ResourceClaimActions { get; }
+}

--- a/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ImportClaimSet.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ImportClaimSet.cs
@@ -90,14 +90,13 @@ public class ImportClaimSet : IFeature
 
             RuleFor(m => m).Custom((claimSet, context) =>
             {
-                var resourceClaimValidator = new ResourceClaimValidator();
                 var actions = getAllActionsQuery.Execute().Select(x => x.ActionName).ToList();
 
                 if (claimSet.ResourceClaims != null && claimSet.ResourceClaims.Any())
                 {
                     foreach (var resourceClaim in claimSet.ResourceClaims)
                     {
-                        resourceClaimValidator.Validate(resourceClaims, actions, authStrategyNames,
+                        ResourceClaimValidator.Validate(resourceClaims, actions, authStrategyNames,
                             resourceClaim, claimSet.ResourceClaims.ToList(), context, claimSet.Name);
                     }
                 }

--- a/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ResourceClaimValidator.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ResourceClaimValidator.cs
@@ -8,11 +8,11 @@ using FluentValidation;
 
 namespace EdFi.Ods.AdminApi.V3.Features.ClaimSets;
 
-public class ResourceClaimValidator
+public static class ResourceClaimValidator
 {
     private static List<string>? _duplicateResources = [];
 
-    public void Validate<T>(Lookup<string, ResourceClaim> dbResourceClaims, List<string> dbActions,
+    public static void Validate<T>(Lookup<string, ResourceClaim> dbResourceClaims, List<string> dbActions,
         List<string?> dbAuthStrategies, ClaimSetResourceClaimModel resourceClaim, List<ClaimSetResourceClaimModel> existingResourceClaims,
         ValidationContext<T> context, string? claimSetName)
     {
@@ -28,7 +28,7 @@ public class ResourceClaimValidator
         ValidateIfExist(context, propertyName, resources);
         ValidateAuthStrategies(dbAuthStrategies, resourceClaim, context, propertyName);
         ValidateAuthStrategiesOverride(dbAuthStrategies, resourceClaim, context, propertyName);
-        ValidateChildren(dbResourceClaims, dbActions, dbAuthStrategies, resourceClaim, context, claimSetName, propertyName, resources);
+        ValidateParentClaimName(resourceClaim, context, propertyName, resources);
     }
 
     public static void Validate<T>(Lookup<int, ResourceClaim> dbResourceClaims, List<string> dbActions, IResourceClaimOnClaimSetRequest editResourceClaimOnClaimSetRequest,
@@ -66,33 +66,26 @@ public class ResourceClaimValidator
         }
     }
 
-    private void ValidateChildren<T>(Lookup<string, ResourceClaim> dbResourceClaims, List<string> dbActions,
-        List<string?> dbAuthStrategies, ClaimSetResourceClaimModel resourceClaim,
-        ValidationContext<T> context, string? claimSetName, string propertyName, List<ResourceClaim> resources)
+    private static void ValidateParentClaimName<T>(ClaimSetResourceClaimModel resourceClaim,
+        ValidationContext<T> context, string propertyName, List<ResourceClaim> resources)
     {
-        if (resourceClaim.Children.Any())
+        if (resourceClaim.ParentClaimName == null)
         {
-            foreach (var child in resourceClaim.Children)
-            {
-                var childResources = dbResourceClaims[child.Name!.ToLower()].ToList();
-                if (childResources.Any())
-                {
-                    foreach (var childResource in childResources)
-                    {
-                        context.MessageFormatter.AppendArgument("ChildResource", childResource.Name);
-                        if (childResource.ParentId == 0)
-                        {
-                            context.AddFailure(propertyName, "'{ChildResource}' can not be added as a child resource.");
-                        }
+            return;
+        }
 
-                        else if (!resources.Where(x => x is not null).Select(x => x.Id).Contains(childResource.ParentId))
-                        {
-                            context.MessageFormatter.AppendArgument("CorrectParentResource", childResource.ParentName);
-                            context.AddFailure(propertyName, "Child resource: '{ChildResource}' added to the wrong parent resource. Correct parent resource is: '{CorrectParentResource}'.");
-                        }
-                    }
-                }
-                Validate(dbResourceClaims, dbActions, dbAuthStrategies, child, resourceClaim.Children, context, claimSetName);
+        foreach (var resource in resources)
+        {
+            context.MessageFormatter.AppendArgument("ChildResource", resource.Name);
+
+            if (resource.ParentClaimName == null)
+            {
+                context.AddFailure(propertyName, "'{ChildResource}' can not be added as a child resource.");
+            }
+            else if (!resource.ParentClaimName.Equals(resourceClaim.ParentClaimName, StringComparison.OrdinalIgnoreCase))
+            {
+                context.MessageFormatter.AppendArgument("CorrectParentResource", resource.ParentName);
+                context.AddFailure(propertyName, "Child resource: '{ChildResource}' added to the wrong parent resource. Correct parent resource is: '{CorrectParentResource}'.");
             }
         }
     }
@@ -100,9 +93,9 @@ public class ResourceClaimValidator
     private static void ValidateAuthStrategiesOverride<T>(List<string?> dbAuthStrategies,
         ClaimSetResourceClaimModel resourceClaim, ValidationContext<T> context, string propertyName)
     {
-        if (resourceClaim.AuthorizationStrategyOverridesForCRUD != null && resourceClaim.AuthorizationStrategyOverridesForCRUD.Any())
+        if (resourceClaim.AuthorizationStrategyOverrides != null && resourceClaim.AuthorizationStrategyOverrides.Any())
         {
-            foreach (var authStrategyOverrideWithAction in resourceClaim.AuthorizationStrategyOverridesForCRUD)
+            foreach (var authStrategyOverrideWithAction in resourceClaim.AuthorizationStrategyOverrides)
             {
                 if (authStrategyOverrideWithAction?.AuthorizationStrategies != null)
                 {
@@ -122,9 +115,9 @@ public class ResourceClaimValidator
     private static void ValidateAuthStrategies<T>(List<string?> dbAuthStrategies,
         ClaimSetResourceClaimModel resourceClaim, ValidationContext<T> context, string propertyName)
     {
-        if (resourceClaim.DefaultAuthorizationStrategiesForCRUD != null && resourceClaim.DefaultAuthorizationStrategiesForCRUD.Any())
+        if (resourceClaim.DefaultAuthorizationStrategies != null && resourceClaim.DefaultAuthorizationStrategies.Any())
         {
-            foreach (var defaultASWithAction in resourceClaim.DefaultAuthorizationStrategiesForCRUD)
+            foreach (var defaultASWithAction in resourceClaim.DefaultAuthorizationStrategies)
             {
                 if (defaultASWithAction?.AuthorizationStrategies == null)
                 {

--- a/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ResourceClaimValidator.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Features/ClaimSets/ResourceClaimValidator.cs
@@ -10,7 +10,7 @@ namespace EdFi.Ods.AdminApi.V3.Features.ClaimSets;
 
 public static class ResourceClaimValidator
 {
-    private static List<string>? _duplicateResources = [];
+    private const string ReportedDuplicatesKey = "ResourceClaimValidator_ReportedDuplicates";
 
     public static void Validate<T>(Lookup<string, ResourceClaim> dbResourceClaims, List<string> dbActions,
         List<string?> dbAuthStrategies, ClaimSetResourceClaimModel resourceClaim, List<ClaimSetResourceClaimModel> existingResourceClaims,
@@ -24,7 +24,13 @@ public static class ResourceClaimValidator
 
         ValidateCRUD(resourceClaim.Actions, dbActions, context, propertyName);
 
-        var resources = dbResourceClaims[resourceClaim.Name!.ToLower()].ToList();
+        if (string.IsNullOrEmpty(resourceClaim.Name))
+        {
+            context.AddFailure(propertyName, "Resource claim name can not be empty.");
+            return;
+        }
+
+        var resources = dbResourceClaims[resourceClaim.Name.ToLower()].ToList();
         ValidateIfExist(context, propertyName, resources);
         ValidateAuthStrategies(dbAuthStrategies, resourceClaim, context, propertyName);
         ValidateAuthStrategiesOverride(dbAuthStrategies, resourceClaim, context, propertyName);
@@ -55,13 +61,23 @@ public static class ResourceClaimValidator
     {
         if (existingResourceClaims.Count(x => x.Name == resourceClaim.Name) > 1)
         {
-            if (_duplicateResources == null || resourceClaim.Name == null ||
-                _duplicateResources.Contains(resourceClaim.Name))
+            if (resourceClaim.Name == null)
             {
                 return;
             }
 
-            _duplicateResources.Add(resourceClaim.Name);
+            if (!context.RootContextData.TryGetValue(ReportedDuplicatesKey, out var reportedValue) ||
+                reportedValue is not HashSet<string> reportedDuplicates)
+            {
+                reportedDuplicates = new HashSet<string>();
+                context.RootContextData[ReportedDuplicatesKey] = reportedDuplicates;
+            }
+
+            if (!reportedDuplicates.Add(resourceClaim.Name))
+            {
+                return;
+            }
+
             context.AddFailure(propertyName, "Only unique resource claims can be added. The following is a duplicate resource: '{ResourceClaimName}'.");
         }
     }

--- a/Application/EdFi.Ods.AdminApi.V3/Infrastructure/Database/Queries/GetResourceClaimsAsFlatListQuery.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Infrastructure/Database/Queries/GetResourceClaimsAsFlatListQuery.cs
@@ -30,7 +30,9 @@ public class GetResourceClaimsAsFlatListQuery : IGetResourceClaimsAsFlatListQuer
                 Id = x.ResourceClaimId,
                 Name = x.ResourceName,
                 ParentId = x.ParentResourceClaimId ?? 0,
-                ParentName = x.ParentResourceClaim.ResourceName
+                ParentName = x.ParentResourceClaim.ResourceName,
+                ClaimName = x.ClaimName,
+                ParentClaimName = x.ParentResourceClaim.ClaimName
             })
             .Distinct()
             .OrderBy(x => x.Name)

--- a/Application/EdFi.Ods.AdminApi.V3/Infrastructure/Services/ClaimSetEditor/AuthorizationStrategy.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Infrastructure/Services/ClaimSetEditor/AuthorizationStrategy.cs
@@ -4,14 +4,23 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using Swashbuckle.AspNetCore.Annotations;
+using System.Text.Json.Serialization;
 
 namespace EdFi.Ods.AdminApi.V3.Infrastructure.ClaimSetEditor;
 
 [SwaggerSchema(Title = "ResourceClaimAuthorizationStrategy")]
 public class AuthorizationStrategy
 {
+    // Used internally by AuthStrategyResolver/GetResourcesByClaimSetIdQuery to resolve and
+    // compare authorization strategy rows. Hidden from the v3 JSON payload per the v3 API
+    // design (only authStrategyName is part of the public contract), but kept on this class
+    // (rather than removed) because response DTOs reference this exact object instance.
+    [JsonIgnore]
     public int AuthStrategyId { get; set; }
+
     public string? AuthStrategyName { get; set; }
+
+    [JsonIgnore]
     public bool IsInheritedFromParent { get; set; }
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/Infrastructure/Services/ClaimSetEditor/ClaimSetResourceClaimActionAuthStrategies.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Infrastructure/Services/ClaimSetEditor/ClaimSetResourceClaimActionAuthStrategies.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using Swashbuckle.AspNetCore.Annotations;
+using System.Text.Json.Serialization;
 
 namespace EdFi.Ods.AdminApi.V3.Infrastructure.ClaimSetEditor;
 
@@ -17,6 +18,7 @@ public interface IClaimSetResourceClaimActionAuthStrategies
 [SwaggerSchema(Title = "ClaimSetResourceClaimActionAuthorizationStrategies")]
 public class ClaimSetResourceClaimActionAuthStrategies : IClaimSetResourceClaimActionAuthStrategies
 {
+    [JsonIgnore]
     public int? ActionId { get; set; }
     public string? ActionName { get; set; }
     public IEnumerable<AuthorizationStrategy>? AuthorizationStrategies { get; set; }

--- a/Application/EdFi.Ods.AdminApi.V3/Infrastructure/Services/ClaimSetEditor/GetResourcesByClaimSetIdQuery.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Infrastructure/Services/ClaimSetEditor/GetResourcesByClaimSetIdQuery.cs
@@ -75,6 +75,7 @@ namespace EdFi.Ods.AdminApi.V3.Infrastructure.ClaimSetEditor
             {
                 Id = x.Key.ResourceClaimId,
                 Name = x.Key.ResourceName,
+                ClaimName = x.Key.ClaimName,
                 Actions = x.Where(x => x.Action != null).Select(x =>
                              new ResourceClaimAction { Name = x.Action.ActionName, Enabled = true}).ToList(),
                 IsParent = true,
@@ -298,6 +299,7 @@ namespace EdFi.Ods.AdminApi.V3.Infrastructure.ClaimSetEditor
                     Id = x.Key.ResourceClaimId,
                     ParentId = x.Key.ParentResourceClaimId ?? 0,
                     Name = x.Key.ResourceName,
+                    ClaimName = x.Key.ClaimName,
                     Actions = x.Where(x => x.Action != null).Select(x =>
                              new ResourceClaimAction { Name = x.Action.ActionName, Enabled = true }).ToList(),
                     IsParent = false,

--- a/Application/EdFi.Ods.AdminApi.V3/Infrastructure/Services/ClaimSetEditor/ResourceClaim.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Infrastructure/Services/ClaimSetEditor/ResourceClaim.cs
@@ -14,6 +14,21 @@ namespace EdFi.Ods.AdminApi.V3.Infrastructure.ClaimSetEditor
         public int ParentId { get; set; }
         public string? ParentName { get; set; }
         public string? Name { get; set; }
+
+        /// <summary>
+        /// The resource claim's full claim URI (e.g. "http://ed-fi.org/identity/claims/candidatePreparation").
+        /// Populated from the security database's ResourceClaim.ClaimName column. Used by
+        /// ClaimSetMapper to build the public v3 claimName/parentClaimName payload shape and by
+        /// ResourceClaimValidator to validate import parent/child relationships.
+        /// </summary>
+        public string? ClaimName { get; set; }
+
+        /// <summary>
+        /// The claim URI of this resource claim's parent, or null if this is a root resource claim.
+        /// Populated only where the query explicitly projects it (see GetResourceClaimsAsFlatListQuery).
+        /// </summary>
+        public string? ParentClaimName { get; set; }
+
         public List<ResourceClaimAction>? Actions { get; set; }
         [JsonIgnore]
         public bool IsParent { get; set; }


### PR DESCRIPTION
Jira Issues related to this PR: [[ADMINAPI-1440](https://edfi.atlassian.net/browse/ADMINAPI-1440) / [ADMINAPI-1441](https://edfi.atlassian.net/browse/ADMINAPI-1441) / [ADMINAPI-1442](https://edfi.atlassian.net/browse/ADMINAPI-1442)]

This pull request updates the ClaimSet export and related tests to align the API response shape with the read endpoint and to simplify and clarify the resource claim model. The changes also update E2E tests and their schemas to match the new payload structure and naming conventions.

**API Response and Model Alignment:**

* The export endpoint now returns a payload with the same shape as the read endpoint, ensuring consistency across both APIs. A new test verifies that the payloads are identical.
* The resource claim model is now flat, with `claimName` and `parentClaimName` fields present at the top level, and the children are flattened in the export.

**Test and Schema Updates:**

* E2E test assertions and response schemas are updated to expect `claimSetName` instead of `name`, and to require `claimSetName` in the payload. (Fd9994ebL22R22, [[1]](diffhunk://#diff-2d282e50caec287f84329bade3d4e69ad98ace9adea47360856ecfb1ec016028L128-R129) [[2]](diffhunk://#diff-69c50cc8aa7e0567b92f7fa96243824c6d969ff2986cb2d23475c7bc6cbf0946L40-R40) [[3]](diffhunk://#diff-69c50cc8aa7e0567b92f7fa96243824c6d969ff2986cb2d23475c7bc6cbf0946L53-R53) [[4]](diffhunk://#diff-cdce598037cf2ca93b5f36e3a03f1fee51478ce087626a2f742fc729abd70395L36-R36) [[5]](diffhunk://#diff-cdce598037cf2ca93b5f36e3a03f1fee51478ce087626a2f742fc729abd70395L49-R49) [[6]](diffhunk://#diff-716bcdc7fc75998743dcfdec4abd2201562a9c31219d4941c23e6a7778bd29a2L40-R40) [[7]](diffhunk://#diff-716bcdc7fc75998743dcfdec4abd2201562a9c31219d4941c23e6a7778bd29a2L53-R53) [[8]](diffhunk://#diff-69e715daede0e4244bfce623bfbd11574dad8cf83edf3d60b1aa6f339574432dL25-R31)
* Resource claim objects now include `claimName` and `parentClaimName` properties in the schema. [[1]](diffhunk://#diff-2d282e50caec287f84329bade3d4e69ad98ace9adea47360856ecfb1ec016028R42-R47) [[2]](diffhunk://#diff-69e715daede0e4244bfce623bfbd11574dad8cf83edf3d60b1aa6f339574432dR49-R54)
* The `children` property is removed from the schema, reflecting the flattened resource claim model.

**Authorization Strategy Schema Simplification:**

* The `_defaultAuthorizationStrategiesForCRUD` and `authorizationStrategyOverridesForCRUD` fields are renamed to `_defaultAuthorizationStrategies` and `authorizationStrategyOverrides`, and their schemas are simplified to remove unused fields like `actionId`, `authStrategyId`, and `isInheritedFromParent`. [[1]](diffhunk://#diff-2d282e50caec287f84329bade3d4e69ad98ace9adea47360856ecfb1ec016028L58-L66) [[2]](diffhunk://#diff-2d282e50caec287f84329bade3d4e69ad98ace9adea47360856ecfb1ec016028L76-L85) [[3]](diffhunk://#diff-2d282e50caec287f84329bade3d4e69ad98ace9adea47360856ecfb1ec016028L94-L102) [[4]](diffhunk://#diff-2d282e50caec287f84329bade3d4e69ad98ace9adea47360856ecfb1ec016028L112-L119) [[5]](diffhunk://#diff-69e715daede0e4244bfce623bfbd11574dad8cf83edf3d60b1aa6f339574432dL64-L72) [[6]](diffhunk://#diff-69e715daede0e4244bfce623bfbd11574dad8cf83edf3d60b1aa6f339574432dL82-L91) [[7]](diffhunk://#diff-69e715daede0e4244bfce623bfbd11574dad8cf83edf3d60b1aa6f339574432dL100-L108)

**Unit Test Improvements:**

* Additional tests verify the correct mapping and flattening of resource claims, including parent-child relationships and field mappings.
* Tests for claim set resource retrieval now check `ClaimName` fields for both parents and children. [[1]](diffhunk://#diff-6bdb42762197bb101aad899b590f548c07222617778f5ba8f4a36b06a2d96240R36) [[2]](diffhunk://#diff-6bdb42762197bb101aad899b590f548c07222617778f5ba8f4a36b06a2d96240R90)

[ADMINAPI-1440]: https://edfi.atlassian.net/browse/ADMINAPI-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ADMINAPI-1441]: https://edfi.atlassian.net/browse/ADMINAPI-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ADMINAPI-1442]: https://edfi.atlassian.net/browse/ADMINAPI-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ