### PR TITLE
[ADMINAPI-1467] Rename admin-api to management-api in V3 problem details URNs

### DIFF
--- a/Application/EdFi.Ods.AdminApi.V3.UnitTests/Infrastructure/ErrorHandling/V3RequestErrorMiddlewareTests.cs
+++ b/Application/EdFi.Ods.AdminApi.V3.UnitTests/Infrastructure/ErrorHandling/V3RequestErrorMiddlewareTests.cs
@@ -169,8 +169,8 @@ public class V3RequestErrorMiddlewareTests
     [Test]
     public async Task InvokeAsync_WhenPipelineAlreadyReturnsProblemDetails_DoesNotOverwriteBody()
     {
-        const string existingBody =
-            "{\"type\":\"urn:ed-fi:admin-api:bad-request:version-mismatch\",\"title\":\"Bad Request\",\"status\":400,\"detail\":\"Wrong API version for this instance mode.\"}";
+        var existingBody =
+            $"{{\"type\":\"{AdminApiProblemTypes.BadRequestVersionMismatch}\",\"title\":\"Bad Request\",\"status\":400,\"detail\":\"Wrong API version for this instance mode.\"}}";
 
         var middleware = new V3RequestErrorMiddleware(async context =>
         {

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Actions/GET - Authstrategies - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Actions/GET - Authstrategies - Invalid Api Mode.bru
@@ -32,7 +32,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/DELETE - ApiClients - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/DELETE - ApiClients - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/DELETE - ApiClients - Invalid Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/DELETE - ApiClients - Invalid Not Found.bru
@@ -30,7 +30,7 @@ script:post-response {
   
   test("PUT ApiClients NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/GET - ApiClients By Application - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/GET - ApiClients By Application - Invalid Api Mode.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/GET - ApiClients by Id - Invalid Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/GET - ApiClients by Id - Invalid Not Found.bru
@@ -30,7 +30,7 @@ script:post-response {
   
   test("PUT ApiClients NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/POST - ApiClients - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/POST - ApiClients - Invalid Api Mode.bru
@@ -39,7 +39,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/POST - ApiClients - Invalid No Application Id.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/POST - ApiClients - Invalid No Application Id.bru
@@ -47,7 +47,7 @@ script:post-response {
   
   test("POST ApiClients Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/POST - ApiClients - Invalid No Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/POST - ApiClients - Invalid No Name.bru
@@ -47,7 +47,7 @@ script:post-response {
   
   test("POST ApiClients Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/POST - ApiClients - Invalid No Ods Instances.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/POST - ApiClients - Invalid No Ods Instances.bru
@@ -45,7 +45,7 @@ script:post-response {
   
   test("POST ApiClients Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - ApiClients - ID Mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - ApiClients - ID Mismatch.bru
@@ -41,7 +41,7 @@ script:post-response {
   
   test("PUT ApiClients ID Mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - ApiClients - ID Missing in Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - ApiClients - ID Missing in Body.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("PUT ApiClients ID Missing in Body: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - ApiClients - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - ApiClients - Invalid Api Mode.bru
@@ -38,7 +38,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - ApiClients - Invalid No Ods Instances.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - ApiClients - Invalid No Ods Instances.bru
@@ -42,7 +42,7 @@ script:post-response {
   
   test("POST ApiClients Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - ApiClients - Invalid Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - ApiClients - Invalid Not Found.bru
@@ -42,7 +42,7 @@ script:post-response {
   
   test("PUT ApiClients NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - Reset Credential - Invalid Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ApiClient/PUT - Reset Credential - Invalid Not Found.bru
@@ -30,7 +30,7 @@ script:post-response {
   
   test("PUT ApiClients NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/DELETE - Applications - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/DELETE - Applications - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/DELETE - Applications - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/DELETE - Applications - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("DEL Application NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
   bru.deleteVar("ApplicationVendorId");

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/GET - Applications - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/GET - Applications - Invalid Api Mode.bru
@@ -32,7 +32,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/GET - Applications - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/GET - Applications - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("GET Application NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid Api Mode.bru
@@ -119,7 +119,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid ClaimSetName With Whitespace.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid ClaimSetName With Whitespace.bru
@@ -44,7 +44,7 @@ script:post-response {
   
   test("POST Applications Invalid ClaimSetName With Whitespace: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid DataStore.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid DataStore.bru
@@ -46,7 +46,7 @@ script:post-response {
   
   test("POST Applications Invalid DataStore: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid Profile.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid Profile.bru
@@ -46,7 +46,7 @@ script:post-response {
   
   test("POST Applications Invalid Profile: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid Vendor.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid Vendor.bru
@@ -45,7 +45,7 @@ script:post-response {
   
   test("POST Applications Invalid Vendor: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/POST - Applications - Invalid.bru
@@ -46,7 +46,7 @@ script:post-response {
   
   test("POST Applications Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - ID Mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - ID Mismatch.bru
@@ -42,7 +42,7 @@ script:post-response {
   
   test("PUT Applications ID Mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - ID Missing in Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - ID Missing in Body.bru
@@ -41,7 +41,7 @@ script:post-response {
   
   test("PUT Applications ID Missing in Body: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid Api Mode.bru
@@ -41,7 +41,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid ClaimSetName With Whitespace.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid ClaimSetName With Whitespace.bru
@@ -45,7 +45,7 @@ script:post-response {
   
   test("PUT Applications Invalid ClaimSetName With Whitespace: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid DataStore.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid DataStore.bru
@@ -47,7 +47,7 @@ script:post-response {
   
   test("PUT Application Invalid DataStore: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid Profile.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid Profile.bru
@@ -47,7 +47,7 @@ script:post-response {
   
   test("PUT Application Invalid Profile: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid Vendor.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid Vendor.bru
@@ -46,7 +46,7 @@ script:post-response {
   
   test("PUT Application Invalid Vendor: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Invalid.bru
@@ -47,7 +47,7 @@ script:post-response {
   
   test("PUT Application Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Applications - Not Found.bru
@@ -43,7 +43,7 @@ script:post-response {
   
   test("PUT Application NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Reset Credential - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Reset Credential - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Reset Credential - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Application/PUT - Reset Credential - Not Found.bru
@@ -30,7 +30,7 @@ script:post-response {
   
   test("PUT Reset Credential NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/AuthorizationStrategies/GET - AuthorizationStrategies - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/AuthorizationStrategies/GET - AuthorizationStrategies - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ClaimSets - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ClaimSets - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ClaimSets - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ClaimSets - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("DEL ClaimSet NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
   bru.deleteVar("CreatedClaimSetId");

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ClaimSets - System Reserved.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ClaimSets - System Reserved.bru
@@ -35,7 +35,7 @@ script:post-response {
   
   test("DEL ClaimSets System Reserved: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
   bru.deleteVar("SystemReservedClaimSetId");

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ClaimSets - With Applications.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ClaimSets - With Applications.bru
@@ -175,7 +175,7 @@ script:post-response {
   
   test("DEL ClaimSets With Application: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
   bru.deleteVar("OtherApplicationId");

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ResourceClaimClaimSets - Delete - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ResourceClaimClaimSets - Delete - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ResourceClaimClaimSets - Delete Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ResourceClaimClaimSets - Delete Not Found.bru
@@ -17,7 +17,7 @@ script:post-response {
   
   test("DELETE ResourceClaimOnClaimSet: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ResourceClaimClaimSets - Delete System Reserved.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/DELETE - ResourceClaimClaimSets - Delete System Reserved.bru
@@ -96,7 +96,7 @@ script:post-response {
   
   test("DELETE ResourceClaimOnClaimSet System Reserved: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Export - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Export - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Export - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Export - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("GET ClaimSet NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/GET - ClaimSets - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("GET ClaimSet NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Api Mode.bru
@@ -129,7 +129,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Existing ClaimSet Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Existing ClaimSet Name.bru
@@ -197,7 +197,7 @@ script:post-response {
   
   test("POST ClaimSets - Import: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Name With Whitespace.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Name With Whitespace.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("POST ClaimSets/Import Invalid Name With Whitespace: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Resource Duplication.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Resource Duplication.bru
@@ -137,7 +137,7 @@ script:post-response {
   
   test("POST ClaimSets - Import: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Wrong Parent Child Relationship.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Invalid Wrong Parent Child Relationship.bru
@@ -137,7 +137,7 @@ script:post-response {
   
   test("POST ClaimSets - Import: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Wrong resource name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Import - Wrong resource name.bru
@@ -137,7 +137,7 @@ script:post-response {
   
   test("POST ClaimSets - Import: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Invalid Api Mode.bru
@@ -37,7 +37,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Invalid Existing ClaimSet Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Invalid Existing ClaimSet Name.bru
@@ -103,7 +103,7 @@ script:post-response {
   
   test("POST ClaimSets Invalid Existing ClaimSets: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Invalid JSON.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Invalid JSON.bru
@@ -51,7 +51,7 @@ script:post-response {
   
   test("POST ClaimSets Invalid Json: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Invalid Name With Whitespace.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Invalid Name With Whitespace.bru
@@ -39,7 +39,7 @@ script:post-response {
   
   test("POST ClaimSets Invalid Name With Whitespace: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Invalid.bru
@@ -39,7 +39,7 @@ script:post-response {
   
   test("POST ClaimSets Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Malformed Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets - Malformed Body.bru
@@ -30,7 +30,7 @@ script:post-response {
   });
 
   test("POST ClaimSets Malformed Body: type URN is correct", function () {
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:data");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:data");
   });
 
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets-Copy - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets-Copy - Invalid Api Mode.bru
@@ -97,7 +97,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets-Copy - Invalid Name With Whitespace.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets-Copy - Invalid Name With Whitespace.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("POST ClaimSets/Copy Invalid Name With Whitespace: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets-Copy- Invalid ClaimSet Id.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets-Copy- Invalid ClaimSet Id.bru
@@ -45,7 +45,7 @@ script:post-response {
   
   test("POST ClaimSet NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
   

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets-Copy- Invalid Existing ClaimSet Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ClaimSets-Copy- Invalid Existing ClaimSet Name.bru
@@ -106,7 +106,7 @@ script:post-response {
   
   test("POST ClaimSets Invalid Existing ClaimSets: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Add Action System Reserved.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Add Action System Reserved.bru
@@ -120,7 +120,7 @@ script:post-response {
   
   test("POST ResourceClaimAction System Reserved: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Add Action Validation Errors.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Add Action Validation Errors.bru
@@ -50,7 +50,7 @@ script:post-response {
   
   test("POST ResourceClaimAction Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Add duplicate action Validation Errors.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Add duplicate action Validation Errors.bru
@@ -50,7 +50,7 @@ script:post-response {
   
   test("POST ResourceClaimAction Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Override Auth Strategy - Action not enabled.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Override Auth Strategy - Action not enabled.bru
@@ -43,7 +43,7 @@ script:post-response {
   
   test("POST OverrideAuthStrategy - Action not enabled: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Override Auth Strategy System Reserved.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Override Auth Strategy System Reserved.bru
@@ -106,7 +106,7 @@ script:post-response {
   
   test("POST OverrideAuthStrategy System Reserved: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Override Auth Strategy Validation Errors.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Override Auth Strategy Validation Errors.bru
@@ -45,7 +45,7 @@ script:post-response {
   
   test("POST OverrideAuthStrategy Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Reset Authorization Strategies Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Reset Authorization Strategies Not Found.bru
@@ -17,7 +17,7 @@ script:post-response {
   
   test("POST ResetAuthorizationStrategies: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Reset Authorization Strategies System Reserved.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/POST - ResourceClaimClaimSets - Reset Authorization Strategies System Reserved.bru
@@ -96,7 +96,7 @@ script:post-response {
   
   test("POST ResetAuthorizationStrategies System Reserved: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - ID Mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - ID Mismatch.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("PUT ClaimSets ID Mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - ID Missing in Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - ID Missing in Body.bru
@@ -35,7 +35,7 @@ script:post-response {
   
   test("PUT ClaimSets ID Missing in Body: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Invalid Api Mode.bru
@@ -34,7 +34,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Invalid Existing ClaimSet Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Invalid Existing ClaimSet Name.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("PUT ClaimSets Invalid Existing ClaimSets: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Invalid JSON.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Invalid JSON.bru
@@ -53,7 +53,7 @@ script:post-response {
   
   test("PUT ClaimSets Invalid Json: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Invalid Name With Whitespace.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Invalid Name With Whitespace.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("PUT ClaimSets Invalid Name With Whitespace: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Invalid.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("PUT ClaimSets Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - Not Found.bru
@@ -35,7 +35,7 @@ script:post-response {
   
   test("PUT ClaimSet NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - System Reserved.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ClaimSets - System Reserved.bru
@@ -106,7 +106,7 @@ script:post-response {
   
   test("PUT ClaimSets System Reserved: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action ClaimSet not found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action ClaimSet not found.bru
@@ -53,7 +53,7 @@ script:post-response {
   
   test("PUT ResourceClaimAction Not Found: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action ClaimSetId Mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action ClaimSetId Mismatch.bru
@@ -54,7 +54,7 @@ script:post-response {
   
   test("PUT ResourceClaimClaimSets ClaimSetId Mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action ClaimSetId Missing in Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action ClaimSetId Missing in Body.bru
@@ -53,7 +53,7 @@ script:post-response {
   
   test("PUT ResourceClaimClaimSets ClaimSetId Missing in Body: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action ResourceClaimId Mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action ResourceClaimId Mismatch.bru
@@ -54,7 +54,7 @@ script:post-response {
   
   test("PUT ResourceClaimClaimSets ResourceClaimId Mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action ResourceClaimId Missing in Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action ResourceClaimId Missing in Body.bru
@@ -53,7 +53,7 @@ script:post-response {
   
   test("PUT ResourceClaimClaimSets ResourceClaimId Missing in Body: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action System Reserved.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ClaimSets/PUT - ResourceClaimClaimSets - Modify Action System Reserved.bru
@@ -121,7 +121,7 @@ script:post-response {
   
   test("PUT ResourceClaimAction System Reserved: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/DELETE - DataStoreContexts - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/DELETE - DataStoreContexts - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/DELETE - DataStoreContexts - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/DELETE - DataStoreContexts - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("DELETE DataStoreContexts NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/GET - DataStoreContexts - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/GET - DataStoreContexts - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/GET - DataStoreContexts by ID - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/GET - DataStoreContexts by ID - Not Found.bru
@@ -29,7 +29,7 @@ script:post-response {
   
   test("GET DataStoreContexts NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/POST - DataStoreContexts - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/POST - DataStoreContexts - Invalid Api Mode.bru
@@ -88,7 +88,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/POST - DataStoreContexts - Invalid Combined Key.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/POST - DataStoreContexts - Invalid Combined Key.bru
@@ -38,7 +38,7 @@ script:post-response {
   
   test("POST DataStore Contexts Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
   

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/POST - DataStoreContexts - Invalid ODS Instance.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/POST - DataStoreContexts - Invalid ODS Instance.bru
@@ -41,7 +41,7 @@ script:post-response {
   
   test("POST DataStore Contexts Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/POST - DataStoreContexts - Not Found ODS Instance.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/POST - DataStoreContexts - Not Found ODS Instance.bru
@@ -38,7 +38,7 @@ script:post-response {
   
   test("POST DataStore Contexts Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/POSt - DataStoreContexts - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/POSt - DataStoreContexts - Invalid.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("POST DataStore Contexts Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - ID Mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - ID Mismatch.bru
@@ -38,7 +38,7 @@ script:post-response {
 
   test("PUT DataStoreContexts ID Mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - ID Missing in Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - ID Missing in Body.bru
@@ -37,7 +37,7 @@ script:post-response {
 
   test("PUT DataStoreContexts ID Missing in Body: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Invalid Api Mode.bru
@@ -35,7 +35,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Invalid Combined Key.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Invalid Combined Key.bru
@@ -104,7 +104,7 @@ script:post-response {
   
   test("PUT DataStoreContexts Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Invalid ODS Instance Id.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Invalid ODS Instance Id.bru
@@ -41,7 +41,7 @@ script:post-response {
   
   test("PUT DataStoreContexts Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Invalid.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("PUT DataStoreContexts Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Not Found ODS Instance Id.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Not Found ODS Instance Id.bru
@@ -39,7 +39,7 @@ script:post-response {
   
   test("PUT DataStoreContexts Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreContexts/PUT - DataStoreContexts - Not Found.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("PUT DataStoreContexts NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/DELETE - DataStoreDerivatives - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/DELETE - DataStoreDerivatives - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/DELETE - DataStoreDerivatives - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/DELETE - DataStoreDerivatives - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("DELETE DataStoreDerivatives NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/GET - DataStoreDerivatives - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/GET - DataStoreDerivatives - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/GET - DataStoreDerivatives by ID - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/GET - DataStoreDerivatives by ID - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("GET DataStoreDerivatives NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid Api Mode.bru
@@ -88,7 +88,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid Combined Key.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid Combined Key.bru
@@ -38,7 +38,7 @@ script:post-response {
   
   test("POST DataStore Derivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid ConnectionString.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid ConnectionString.bru
@@ -35,7 +35,7 @@ script:post-response {
   
   test("POST DataStore Derivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
   

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid Derivative Type.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid Derivative Type.bru
@@ -35,7 +35,7 @@ script:post-response {
   
   test("POST DataStore Derivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
   

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid ODS Instance.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid ODS Instance.bru
@@ -41,7 +41,7 @@ script:post-response {
   
   test("POST DataStore Derivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Invalid.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("POST DataStore Derivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Not Found ODS Instance.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/POST - DataStoreDerivatives - Not Found ODS Instance.bru
@@ -38,7 +38,7 @@ script:post-response {
   
   test("POST DataStore Derivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - ID Mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - ID Mismatch.bru
@@ -38,7 +38,7 @@ script:post-response {
 
   test("PUT DataStoreDerivatives ID Mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - ID Missing in Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - ID Missing in Body.bru
@@ -37,7 +37,7 @@ script:post-response {
 
   test("PUT DataStoreDerivatives ID Missing in Body: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid Api Mode.bru
@@ -35,7 +35,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid Combined Key.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid Combined Key.bru
@@ -103,7 +103,7 @@ script:post-response {
   
   test("PUT DataStoreDerivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid Connection String.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid Connection String.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("PUT DataStoreDerivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
   

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid Derivative Type.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid Derivative Type.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("PUT DataStoreDerivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
   

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid ODS Instance Id.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid ODS Instance Id.bru
@@ -41,7 +41,7 @@ script:post-response {
   
   test("PUT DataStoreDerivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Invalid.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("PUT DataStoreDerivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Not Found ODS Instance Id.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Not Found ODS Instance Id.bru
@@ -38,7 +38,7 @@ script:post-response {
   
   test("PUT DataStoreDerivatives Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStoreDerivatives/PUT - DataStoreDerivatives - Not Found.bru
@@ -39,7 +39,7 @@ script:post-response {
   
   test("PUT DataStoreDerivatives NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/DELETE - DataStores - Applications associated.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/DELETE - DataStores - Applications associated.bru
@@ -33,7 +33,7 @@ script:post-response {
   
   test("DELETE DataStore Applications associated: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/DELETE - DataStores - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/DELETE - DataStores - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/DELETE - DataStores - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/DELETE - DataStores - Not Found.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("DELETE DataStore NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/GET - DataStores - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/GET - DataStores - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/GET - DataStores - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/GET - DataStores - Not Found.bru
@@ -30,7 +30,7 @@ script:post-response {
   
   test("GET DataStores NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - Invalid Api Mode.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - Invalid Connection String.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - Invalid Connection String.bru
@@ -44,7 +44,7 @@ script:post-response {
   
   test("POST DataStores Invalid ConnectionString: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - Invalid Existing Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - Invalid Existing Name.bru
@@ -101,7 +101,7 @@ script:post-response {
   
   test("POST DataStore Invalid Existing DataStore: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/POST - DataStores - Invalid.bru
@@ -46,7 +46,7 @@ script:post-response {
   
   test("POST DataStores Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - ID Mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - ID Mismatch.bru
@@ -38,7 +38,7 @@ script:post-response {
   
   test("PUT DataStores ID Mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - ID Missing in Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - ID Missing in Body.bru
@@ -37,7 +37,7 @@ script:post-response {
   
   test("PUT DataStores ID Missing in Body: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - Invalid Api Mode.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - Invalid Connection String.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - Invalid Connection String.bru
@@ -45,7 +45,7 @@ script:post-response {
   
   test("PUT DataStores Invalid ConnectionString: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - Invalid Existing Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - Invalid Existing Name.bru
@@ -42,7 +42,7 @@ script:post-response {
   
   test("PUT DataStore Invalid Existing DataStore: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DataStores/PUT - DataStores - Not Found.bru
@@ -49,7 +49,7 @@ script:post-response {
   
   test("PUT DataStore NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DbDataStores/DELETE - DbDataStore - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DbDataStores/DELETE - DbDataStore - Not Found.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("DELETE DbDataStore Not Found: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DbDataStores/GET - DbDataStores - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DbDataStores/GET - DbDataStores - Not Found.bru
@@ -28,7 +28,7 @@ script:post-response {
   
   test("GET DbDataStore Not Found: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DbDataStores/POST - DbDataStores - Invalid Database Template.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DbDataStores/POST - DbDataStores - Invalid Database Template.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("POST DbDataStores Invalid Template: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DbDataStores/POST - DbDataStores - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/DbDataStores/POST - DbDataStores - Invalid.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("POST DbDataStores Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Jobs/GET - Job Status by ID - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Jobs/GET - Job Status by ID - Not Found.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("GET Job Status Not Found: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Multitenant Isolation - DataStores/GET - DataStores by ID - Tenant1 - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Multitenant Isolation - DataStores/GET - DataStores by ID - Tenant1 - Invalid Api Mode.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Multitenant Isolation - DataStores/GET - DataStores by ID - Tenant2.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Multitenant Isolation - DataStores/GET - DataStores by ID - Tenant2.bru
@@ -148,7 +148,7 @@ script:post-response {
 
       test("GET DataStores NotFound: type URN is correct", function () {
           const response = res.getBody();
-          expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+          expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
       });
   }
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Multitenant Isolation - DataStores/POST - DataStores - Tenant1 - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Multitenant Isolation - DataStores/POST - DataStores - Tenant1 - Invalid Api Mode.bru
@@ -44,7 +44,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/DELETE - Profiles - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/DELETE - Profiles - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/DELETE - Profiles - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/DELETE - Profiles - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("GET Profile NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/GET - Profile by ID - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/GET - Profile by ID - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("GET Profile NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/GET - Profiles - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/GET - Profiles - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/POST - Profiles - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/POST - Profiles - Invalid Api Mode.bru
@@ -34,7 +34,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/POST - Profiles - Invalid definition xml.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/POST - Profiles - Invalid definition xml.bru
@@ -44,7 +44,7 @@ script:post-response {
   
   test("POST Profiles Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/POST - Profiles - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/POST - Profiles - Invalid.bru
@@ -43,7 +43,7 @@ script:post-response {
   
   test("POST Profiles Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/POST - Profiles - Name mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/POST - Profiles - Name mismatch.bru
@@ -43,7 +43,7 @@ script:post-response {
   
   test("POST Profiles Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/POST - Profiles Duplicate Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/POST - Profiles Duplicate Name.bru
@@ -43,7 +43,7 @@ script:post-response {
   
   test("POST Profiles Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - ID Mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - ID Mismatch.bru
@@ -37,7 +37,7 @@ script:post-response {
   
   test("PUT Profiles ID Mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - ID Missing in Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - ID Missing in Body.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("PUT Profiles ID Missing in Body: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - Invalid Api Mode.bru
@@ -34,7 +34,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - Invalid definition xml.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - Invalid definition xml.bru
@@ -45,7 +45,7 @@ script:post-response {
   
   test("POST Profiles Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - Invalid.bru
@@ -44,7 +44,7 @@ script:post-response {
   
   test("POST Profiles Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - Name mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - Name mismatch.bru
@@ -44,7 +44,7 @@ script:post-response {
   
   test("POST Profiles Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles - Not Found.bru
@@ -39,7 +39,7 @@ script:post-response {
   
   test("GET Profile NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles Duplicate Name.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Profiles/PUT - Profiles Duplicate Name.bru
@@ -105,7 +105,7 @@ script:post-response {
   
   test("PUT Profiles: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
   console.log("🔧 Setting post environment to ignore SSL certificates...");

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ResourceClaimActionAuthStrategies/GET - ResourceClaimActionAuthStrategies - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ResourceClaimActionAuthStrategies/GET - ResourceClaimActionAuthStrategies - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ResourceClaims/GET - Resourceclaims - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ResourceClaims/GET - Resourceclaims - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ResourceClaims/GET - Resourceclaims -Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ResourceClaims/GET - Resourceclaims -Not Found.bru
@@ -30,7 +30,7 @@ script:post-response {
   
   test("GET Resourceclaim NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ResourceClaimsActions/GET - ResourceClaimsActions - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/ResourceClaimsActions/GET - ResourceClaimsActions - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Tenants/GET - Tenants EdOrgs by Tenant Name - Multitenant.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Tenants/GET - Tenants EdOrgs by Tenant Name - Multitenant.bru
@@ -194,7 +194,7 @@ script:post-response {
 
       test("GET Tenants DataStores EdOrgs: type URN is correct", function () {
           const response = res.getBody();
-          expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+          expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
       });
   }
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Tenants/GET - Tenants EdOrgs by Tenant Name - Singletenant.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Tenants/GET - Tenants EdOrgs by Tenant Name - Singletenant.bru
@@ -192,7 +192,7 @@ script:post-response {
 
       test("GET Tenants DataStores EdOrgs: type URN is correct", function () {
           const response = res.getBody();
-          expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+          expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
       });
   }
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/User Management/POST - Register - Already Exists.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/User Management/POST - Register - Already Exists.bru
@@ -39,7 +39,7 @@ script:post-response {
   
   test("POST Register Already Exists: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/User Management/POST - Register - Invalid ClientSecret.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/User Management/POST - Register - Invalid ClientSecret.bru
@@ -43,7 +43,7 @@ script:post-response {
   
   test("POST Register Already Exists: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/User Management/POST - Register - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/User Management/POST - Register - Invalid.bru
@@ -40,7 +40,7 @@ script:post-response {
   
   test("POST Register Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
   

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Validate Exception Content Type/AdminApi Mode Mismatch Returns ProblemDetails.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Validate Exception Content Type/AdminApi Mode Mismatch Returns ProblemDetails.bru
@@ -40,7 +40,7 @@ script:post-response {
   });  
   test("Mode mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 settings {

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/DELETE - Vendors - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/DELETE - Vendors - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/DELETE - Vendors - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/DELETE - Vendors - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("DEL Vendors NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
   bru.deleteVar("CreatedVendorId");

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/GET - Vendors -  Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/GET - Vendors -  Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("GET Vendors NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/GET - Vendors - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/GET - Vendors - Invalid Api Mode.bru
@@ -27,7 +27,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/GET - Vendors with Invalid Application - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/GET - Vendors with Invalid Application - Not Found.bru
@@ -31,7 +31,7 @@ script:post-response {
   
   test("GET Vendors NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/POST - Vendors - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/POST - Vendors - Invalid Api Mode.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/POST - Vendors - Invalid Prefix exceed length.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/POST - Vendors - Invalid Prefix exceed length.bru
@@ -41,7 +41,7 @@ script:post-response {
   
   test("POST Vendors Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/POST - Vendors - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/POST - Vendors - Invalid.bru
@@ -43,7 +43,7 @@ script:post-response {
   
   test("POST Vendors Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/PUT - Vendors - ID Mismatch.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/PUT - Vendors - ID Mismatch.bru
@@ -39,7 +39,7 @@ script:post-response {
   
   test("PUT Vendors ID Mismatch: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/PUT - Vendors - ID Missing in Body.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/PUT - Vendors - ID Missing in Body.bru
@@ -38,7 +38,7 @@ script:post-response {
   
   test("PUT Vendors ID Missing in Body: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/PUT - Vendors - Invalid Api Mode.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/PUT - Vendors - Invalid Api Mode.bru
@@ -36,7 +36,7 @@ script:post-response {
   
   test("Type check: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:version-mismatch");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:version-mismatch");
   });
 }
 

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/PUT - Vendors - Invalid.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/PUT - Vendors - Invalid.bru
@@ -43,7 +43,7 @@ script:post-response {
   
   test("PUT Vendors Invalid: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:bad-request:validation");
+      expect(response.type).to.equal("urn:ed-fi:management-api:bad-request:validation");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/PUT - Vendors - Not Found.bru
+++ b/Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/Vendors/PUT - Vendors - Not Found.bru
@@ -42,7 +42,7 @@ script:post-response {
   
   test("PUT Vendors NotFound: type URN is correct", function () {
       const response = res.getBody();
-      expect(response.type).to.equal("urn:ed-fi:admin-api:not-found");
+      expect(response.type).to.equal("urn:ed-fi:management-api:not-found");
   });
   
 }

--- a/Application/EdFi.Ods.AdminApi.V3/Infrastructure/ErrorHandling/AdminApiProblemTypes.cs
+++ b/Application/EdFi.Ods.AdminApi.V3/Infrastructure/ErrorHandling/AdminApiProblemTypes.cs
@@ -7,10 +7,10 @@ namespace EdFi.Ods.AdminApi.V3.Infrastructure.ErrorHandling;
 
 public static class AdminApiProblemTypes
 {
-    public const string BadRequestValidation = "urn:ed-fi:admin-api:bad-request:validation";
-    public const string NotFound = "urn:ed-fi:admin-api:not-found";
-    public const string BadRequestData = "urn:ed-fi:admin-api:bad-request:data";
-    public const string BadRequest = "urn:ed-fi:admin-api:bad-request";
-    public const string InternalServerError = "urn:ed-fi:admin-api:internal-server-error";
-    public const string BadRequestVersionMismatch = "urn:ed-fi:admin-api:bad-request:version-mismatch";
+    public const string BadRequestValidation = "urn:ed-fi:management-api:bad-request:validation";
+    public const string NotFound = "urn:ed-fi:management-api:not-found";
+    public const string BadRequestData = "urn:ed-fi:management-api:bad-request:data";
+    public const string BadRequest = "urn:ed-fi:management-api:bad-request";
+    public const string InternalServerError = "urn:ed-fi:management-api:internal-server-error";
+    public const string BadRequestVersionMismatch = "urn:ed-fi:management-api:bad-request:version-mismatch";
 }

--- a/Docker/Settings/V1/DB-Admin/mssql/Dockerfile
+++ b/Docker/Settings/V1/DB-Admin/mssql/Dockerfile
@@ -3,9 +3,10 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a as base
+FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 as base
 USER root
-RUN apt-get update && apt-get install unzip -y dos2unix busybox openssl>=3.1.7-r0 libxml2>=2.12.5-r0 musl>=1.2.4_git20230717-r5
+RUN apt-get update && apt-get install --no-install-recommends -y unzip dos2unix busybox openssl libxml2 && \
+    rm -rf /var/lib/apt/lists/*
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV MSSQL_DB=master

--- a/Docker/Settings/V1/DB-Admin/mssql/Dockerfile
+++ b/Docker/Settings/V1/DB-Admin/mssql/Dockerfile
@@ -3,10 +3,9 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 as base
+FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a as base
 USER root
-RUN apt-get update && apt-get install --no-install-recommends -y unzip dos2unix busybox openssl libxml2 && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install unzip -y dos2unix busybox openssl>=3.1.7-r0 libxml2>=2.12.5-r0 musl>=1.2.4_git20230717-r5
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV MSSQL_DB=master

--- a/Docker/Settings/V2/DB-Admin/mssql/Dockerfile
+++ b/Docker/Settings/V2/DB-Admin/mssql/Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a AS base
+FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 AS base
 USER root
 RUN apt-get update && apt-get install unzip -y dos2unix busybox openssl libxml2
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"

--- a/Docker/Settings/V2/DB-Admin/mssql/Dockerfile
+++ b/Docker/Settings/V2/DB-Admin/mssql/Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 AS base
+FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a AS base
 USER root
 RUN apt-get update && apt-get install unzip -y dos2unix busybox openssl libxml2
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"

--- a/Docker/Settings/V3/DB-Admin/mssql/Dockerfile
+++ b/Docker/Settings/V3/DB-Admin/mssql/Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a AS base
+FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 AS base
 USER root
 RUN apt-get update && apt-get install unzip -y dos2unix busybox openssl libxml2
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"

--- a/Docker/Settings/V3/DB-Admin/mssql/Dockerfile
+++ b/Docker/Settings/V3/DB-Admin/mssql/Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 AS base
+FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a AS base
 USER root
 RUN apt-get update && apt-get install unzip -y dos2unix busybox openssl libxml2
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"

--- a/Docker/V1/db.mssql.admin.Dockerfile
+++ b/Docker/V1/db.mssql.admin.Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 AS base
+FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a AS base
 USER root
 RUN apt-get update && apt-get install --no-install-recommends -y unzip dos2unix busybox openssl libxml2 && \
     rm -rf /var/lib/apt/lists/*

--- a/Docker/V1/db.mssql.admin.Dockerfile
+++ b/Docker/V1/db.mssql.admin.Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a AS base
+FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 AS base
 USER root
 RUN apt-get update && apt-get install --no-install-recommends -y unzip dos2unix busybox openssl libxml2 && \
     rm -rf /var/lib/apt/lists/*

--- a/Docker/V2/db.mssql.admin.Dockerfile
+++ b/Docker/V2/db.mssql.admin.Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a AS base
+FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 AS base
 USER root
 RUN apt-get update && apt-get install unzip -y dos2unix busybox openssl libxml2
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"

--- a/Docker/V2/db.mssql.admin.Dockerfile
+++ b/Docker/V2/db.mssql.admin.Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 AS base
+FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a AS base
 USER root
 RUN apt-get update && apt-get install unzip -y dos2unix busybox openssl libxml2
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"

--- a/Docker/V3/db.mssql.admin.Dockerfile
+++ b/Docker/V3/db.mssql.admin.Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a AS base
+FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 AS base
 USER root
 RUN apt-get update && apt-get install unzip -y dos2unix busybox openssl libxml2
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"

--- a/Docker/V3/db.mssql.admin.Dockerfile
+++ b/Docker/V3/db.mssql.admin.Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-FROM mcr.microsoft.com/mssql/server:2022-CU15-ubuntu-22.04@sha256:804e527187b16fe05c4321b58d76850966cbaf73e31942416ce0bbefe1b0eb63 AS base
+FROM mcr.microsoft.com/mssql/server@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a AS base
 USER root
 RUN apt-get update && apt-get install unzip -y dos2unix busybox openssl libxml2
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"


### PR DESCRIPTION
## Summary
- Renames the `admin-api` segment to `management-api` in all Problem Details `type` URNs used by Admin API V3 error responses (e.g. `urn:ed-fi:admin-api:not-found` → `urn:ed-fi:management-api:not-found`), per [ADMINAPI-1467](https://edfi.atlassian.net/browse/ADMINAPI-1467).
- Only the six URN string values in `AdminApiProblemTypes` changed — the class/file name is unchanged, since production code only ever references the constants (never hardcodes the URN).
- Replaced the one hardcoded URN literal in `V3RequestErrorMiddlewareTests.cs` with a reference to the `AdminApiProblemTypes` constant so future URN changes won't require touching that test again.
- Updated all 188 Bruno E2E `.bru` files under `Application/EdFi.Ods.AdminApi.V3/E2E Tests/Bruno Admin API E2E 3.0/v3/` that assert on the `type` field to expect the new `management-api` URNs.
- Left the historical design doc (`docs/design/2026-06-26-update-problem-details-type-urn-admin-api-v3.md`) untouched, as it documents the state at the time it was written.

## Test plan
- [x] `./build.ps1 -Command UnitTest` — all V3 unit tests pass (0 failures)
- [x] Verified zero remaining `urn:ed-fi:admin-api` references under `Application/`
- [x] Manual verification confirmed by requester
- [ ] Reviewer may optionally run `./eng/run-e2e-bruno.ps1 -ApiVersion 3 -TenantMode multitenant -TearDown` to confirm Bruno E2E assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Previous URN (admin-api):
<img width="996" height="497" alt="image" src="https://github.com/user-attachments/assets/07500e49-cf7b-44ec-9d40-28dab859ebcb" />

### Current URN (management-api):
<img width="980" height="494" alt="image" src="https://github.com/user-attachments/assets/e017e18e-7b5b-40f2-a26e-00aa258109b4" />


[ADMINAPI-1467]: https://edfi.atlassian.net/browse/ADMINAPI-1467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ